### PR TITLE
Fix FreeRTOS EventGroup crash/lockup in user_leds

### DIFF
--- a/components/user_leds/user_leds.c
+++ b/components/user_leds/user_leds.c
@@ -171,7 +171,7 @@ void user_leds_main(void *arg)
 
 int user_leds_get(struct user_leds *leds, unsigned index)
 {
-  if (index > leds->count) {
+  if (index >= leds->count) {
     LOG_ERROR("invalid index=%u for count=%u", index, leds->count);
     return -1;
   }
@@ -194,7 +194,7 @@ int user_leds_get(struct user_leds *leds, unsigned index)
 
 int user_leds_set(struct user_leds *leds, unsigned index, enum user_leds_state state)
 {
-  if (index > leds->count) {
+  if (index >= leds->count) {
     LOG_ERROR("invalid index=%u for count=%u", index, leds->count);
     return -1;
   }

--- a/main/user_leds.c
+++ b/main/user_leds.c
@@ -117,7 +117,7 @@ static struct gpio_options user_leds_gpio = {
 #endif
 };
 
-static struct user_leds_options user_leds_options[] = {
+static struct user_leds_options user_leds_options[USER_LEDS_COUNT] = {
 #if CONFIG_STATUS_LEDS_USER_ENABLED
   [USER_LED] = {
     .gpio_pin = CONFIG_STATUS_LEDS_USER_GPIO_NUM,

--- a/sdk/esp-idf/patches/freertos-eventgroups-timeout-race.patch
+++ b/sdk/esp-idf/patches/freertos-eventgroups-timeout-race.patch
@@ -1,0 +1,23 @@
+commit 1183eedc56ff36eabff23c4f0067b6325c19f400
+Author: Tero Marttila <terom@fixme.fi>
+Date:   Sat Jul 2 22:59:51 2022 +0300
+
+    freertos: fix eventgroup xEventListItem SMP race with timeout tick interrupt
+
+diff --git a/components/freertos/tasks.c b/components/freertos/tasks.c
+index 40a07839e7..86a3778019 100644
+--- a/components/freertos/tasks.c
++++ b/components/freertos/tasks.c
+@@ -3741,6 +3741,12 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
+ 
+     taskENTER_CRITICAL();
+ 
++    if ( listLIST_ITEM_CONTAINER( pxEventListItem ) == NULL ) {
++      // XXX: https://github.com/espressif/esp-idf/issues/8336
++      taskEXIT_CRITICAL();
++      return;
++    }
++
+     /* Store the new item value in the event list. */
+     listSET_LIST_ITEM_VALUE( pxEventListItem, xItemValue | taskEVENT_LIST_ITEM_VALUE_IN_USE );
+ 


### PR DESCRIPTION
Fixes #23

Add a PoC patch for https://github.com/espressif/esp-idf/issues/8336, which is an SMP race condition when a task running on one core calls `xEventGroupSetBits()` at the same time as the `xEventGroupWaitBits()` timeout for a task running on a different core expires.

Also fix the `user_leds_set()` index check, and make the sdkconfig-based `user_leds_options[USER_LEDS_COUNT]` size explicit, in case the enum values are somehow mis-configured.