### PR TITLE
Optimize leds ->i2s_out stack usage

### DIFF
--- a/components/i2s_out/esp32/dev.c
+++ b/components/i2s_out/esp32/dev.c
@@ -15,16 +15,16 @@ static const periph_module_t i2s_periph_module[I2S_PORT_MAX] = {
   [I2S_PORT_1]  = PERIPH_I2S1_MODULE,
 };
 
-int i2s_out_dev_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
+int i2s_out_dev_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options)
 {
-  if (options.dev_mutex) {
-    LOG_DEBUG("take dev_mutex=%p", options.dev_mutex);
+  if (options->dev_mutex) {
+    LOG_DEBUG("take dev_mutex=%p", options->dev_mutex);
 
-    if (!xSemaphoreTake(options.dev_mutex, portMAX_DELAY)) {
+    if (!xSemaphoreTake(options->dev_mutex, portMAX_DELAY)) {
       LOG_ERROR("xSemaphoreTake");
       return -1;
     } else {
-      i2s_out->dev_mutex = options.dev_mutex;
+      i2s_out->dev_mutex = options->dev_mutex;
 
       LOG_DEBUG("have dev_mutex=%p", i2s_out->dev_mutex);
     }

--- a/components/i2s_out/esp32/dma.c
+++ b/components/i2s_out/esp32/dma.c
@@ -164,17 +164,17 @@ int i2s_out_dma_init(struct i2s_out *i2s_out, size_t size, size_t align)
   return 0;
 }
 
-int i2s_out_dma_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
+int i2s_out_dma_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options)
 {
   LOG_DEBUG("...");
 
-  if (options.eof_count * sizeof(options.eof_value) > DMA_EOF_BUF_SIZE) {
-    LOG_ERROR("eof_count=%u is too large for eof buf size=%u", options.eof_count, DMA_EOF_BUF_SIZE);
+  if (options->eof_count * sizeof(options->eof_value) > DMA_EOF_BUF_SIZE) {
+    LOG_ERROR("eof_count=%u is too large for eof buf size=%u", options->eof_count, DMA_EOF_BUF_SIZE);
     return -1;
   }
 
   // init EOF buffer
-  init_dma_eof_desc(i2s_out->dma_eof_desc, options.eof_value, options.eof_count);
+  init_dma_eof_desc(i2s_out->dma_eof_desc, options->eof_value, options->eof_count);
 
   // init RX desc
   reinit_dma_desc(i2s_out->dma_rx_desc, i2s_out->dma_rx_count, i2s_out->dma_eof_desc);

--- a/components/i2s_out/esp32/i2s.c
+++ b/components/i2s_out/esp32/i2s.c
@@ -11,9 +11,9 @@ int i2s_out_i2s_init(struct i2s_out *i2s_out)
   return 0;
 }
 
-int i2s_out_i2s_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
+int i2s_out_i2s_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options)
 {
-  LOG_DEBUG("clock(clkm=1/%d bck=1/%d)", options.clock.clkm_div, options.clock.bck_div);
+  LOG_DEBUG("clock(clkm=1/%d bck=1/%d)", options->clock.clkm_div, options->clock.bck_div);
 
   taskENTER_CRITICAL(&i2s_out->mux);
 
@@ -30,7 +30,7 @@ int i2s_out_i2s_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
   // TODO: SOC_I2S_SUPPORTS_PDM_RX/TX, SOC_I2S_SUPPORTS_TDM?
   i2s_ll_tx_enable_pdm(i2s_out->dev, false);
 
-  switch (options.mode) {
+  switch (options->mode) {
     case I2S_OUT_MODE_16BIT_SERIAL:
       i2s_ll_enable_lcd(i2s_out->dev, false);
 
@@ -98,11 +98,11 @@ int i2s_out_i2s_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
   i2s_ll_tx_bypass_pcm(i2s_out->dev, true);
 
   // using 160MHz I2S_CLK_D2CLK
-  i2s_ll_mclk_div_t mclk_set = { .mclk_div = options.clock.clkm_div, .b = 0, .a = 1 };
+  i2s_ll_mclk_div_t mclk_set = { .mclk_div = options->clock.clkm_div, .b = 0, .a = 1 };
 
   i2s_ll_tx_clk_set_src(i2s_out->dev, I2S_CLK_D2CLK);
   i2s_ll_tx_set_clk(i2s_out->dev, &mclk_set);
-  i2s_ll_tx_set_bck_div_num(i2s_out->dev, options.clock.bck_div);
+  i2s_ll_tx_set_bck_div_num(i2s_out->dev, options->clock.bck_div);
 
   taskEXIT_CRITICAL(&i2s_out->mux);
 

--- a/components/i2s_out/esp32/intr.c
+++ b/components/i2s_out/esp32/intr.c
@@ -85,7 +85,7 @@ void IRAM_ATTR i2s_intr_handler(void *arg)
   }
 }
 
-int i2s_out_intr_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
+int i2s_out_intr_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options)
 {
   esp_err_t err = 0;
 

--- a/components/i2s_out/esp32/pin.c
+++ b/components/i2s_out/esp32/pin.c
@@ -32,32 +32,32 @@ int i2s_out_pin_init(struct i2s_out *i2s_out)
   return 0;
 }
 
-int i2s_out_pin_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
+int i2s_out_pin_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options)
 {
-  if (options.pin_mutex) {
-    if (!xSemaphoreTake(options.pin_mutex, options.pin_timeout)) {
+  if (options->pin_mutex) {
+    if (!xSemaphoreTake(options->pin_mutex, options->pin_timeout)) {
       LOG_ERROR("xSemaphoreTake");
       return -1;
     } else {
-      i2s_out->pin_mutex = options.pin_mutex;
+      i2s_out->pin_mutex = options->pin_mutex;
     }
   }
 
-  switch (options.mode) {
+  switch (options->mode) {
     case I2S_OUT_MODE_16BIT_SERIAL:
       LOG_DEBUG("port=%d: mode=I2S_OUT_MODE_16BIT_SERIAL bck_gpio=%d serial_data_gpio=%d inv_data_gpio=%d", i2s_out->port,
-        options.bck_gpio,
-        options.data_gpio,
-        options.inv_data_gpio
+        options->bck_gpio,
+        options->data_gpio,
+        options->inv_data_gpio
       );
 
       break;
 
     case I2S_OUT_MODE_32BIT_SERIAL:
       LOG_DEBUG("port=%d: mode=I2S_OUT_MODE_32BIT_SERIAL bck_gpio=%d serial_data_gpio=%d inv_data_gpio=%d", i2s_out->port,
-        options.bck_gpio,
-        options.data_gpio,
-        options.inv_data_gpio
+        options->bck_gpio,
+        options->data_gpio,
+        options->inv_data_gpio
       );
 
       break;
@@ -69,95 +69,95 @@ int i2s_out_pin_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
       }
 
       LOG_DEBUG("port=%d: mode=I2S_OUT_MODE_8BIT_PARALLEL bck_gpio=%d parallel_data_gpio=[%d, %d, %d, %d, %d, %d, %d, %d]", i2s_out->port,
-        options.bck_gpio,
-        options.data_gpios[0],
-        options.data_gpios[1],
-        options.data_gpios[2],
-        options.data_gpios[3],
-        options.data_gpios[4],
-        options.data_gpios[5],
-        options.data_gpios[6],
-        options.data_gpios[7]
+        options->bck_gpio,
+        options->data_gpios[0],
+        options->data_gpios[1],
+        options->data_gpios[2],
+        options->data_gpios[3],
+        options->data_gpios[4],
+        options->data_gpios[5],
+        options->data_gpios[6],
+        options->data_gpios[7]
       );
 
       break;
 
     default:
-      LOG_ERROR("invalid mode=%d", options.mode);
+      LOG_ERROR("invalid mode=%d", options->mode);
       return -1;
   }
 
   taskENTER_CRITICAL(&i2s_out->mux);
 
 
-  switch (options.mode) {
+  switch (options->mode) {
     case I2S_OUT_MODE_16BIT_SERIAL:
     case I2S_OUT_MODE_32BIT_SERIAL:
-      if (options.bck_gpio > 0) {
-        i2s_out->bck_gpios[0] = options.bck_gpio;
+      if (options->bck_gpio > 0) {
+        i2s_out->bck_gpios[0] = options->bck_gpio;
 
-        gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[options.bck_gpio], PIN_FUNC_GPIO);
-        gpio_ll_input_disable(&GPIO, options.bck_gpio);
-        gpio_ll_output_enable(&GPIO, options.bck_gpio);
+        gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[options->bck_gpio], PIN_FUNC_GPIO);
+        gpio_ll_input_disable(&GPIO, options->bck_gpio);
+        gpio_ll_output_enable(&GPIO, options->bck_gpio);
 
-        esp_rom_gpio_connect_out_signal(options.bck_gpio, i2s_bck_out_sig[i2s_out->port], options.bck_inv, false);
+        esp_rom_gpio_connect_out_signal(options->bck_gpio, i2s_bck_out_sig[i2s_out->port], options->bck_inv, false);
       }
 
-      if (options.data_gpio > 0) {
-        i2s_out->data_gpios[0] = options.data_gpio;
+      if (options->data_gpio > 0) {
+        i2s_out->data_gpios[0] = options->data_gpio;
 
-        gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[options.data_gpio], PIN_FUNC_GPIO);
-        gpio_ll_input_disable(&GPIO, options.data_gpio);
-        gpio_ll_output_enable(&GPIO, options.data_gpio);
+        gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[options->data_gpio], PIN_FUNC_GPIO);
+        gpio_ll_input_disable(&GPIO, options->data_gpio);
+        gpio_ll_output_enable(&GPIO, options->data_gpio);
 
-        esp_rom_gpio_connect_out_signal(options.data_gpio, i2s_serial_data_out_sig[i2s_out->port], false, false);
+        esp_rom_gpio_connect_out_signal(options->data_gpio, i2s_serial_data_out_sig[i2s_out->port], false, false);
       }
 
-      if (options.inv_data_gpio > 0) {
-        i2s_out->inv_data_gpios[0] = options.inv_data_gpio;
+      if (options->inv_data_gpio > 0) {
+        i2s_out->inv_data_gpios[0] = options->inv_data_gpio;
 
-        gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[options.inv_data_gpio], PIN_FUNC_GPIO);
-        gpio_ll_input_disable(&GPIO, options.inv_data_gpio);
-        gpio_ll_output_enable(&GPIO, options.inv_data_gpio);
+        gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[options->inv_data_gpio], PIN_FUNC_GPIO);
+        gpio_ll_input_disable(&GPIO, options->inv_data_gpio);
+        gpio_ll_output_enable(&GPIO, options->inv_data_gpio);
 
         // invert gpio output pin
-        esp_rom_gpio_connect_out_signal(options.inv_data_gpio, i2s_serial_data_out_sig[i2s_out->port], true, false);
+        esp_rom_gpio_connect_out_signal(options->inv_data_gpio, i2s_serial_data_out_sig[i2s_out->port], true, false);
       }
 
       break;
 
     case I2S_OUT_MODE_8BIT_PARALLEL:
       for (int i = 0; i < I2S_OUT_PARALLEL_SIZE; i++) {
-        if (options.bck_gpios[i] > 0) {
-          i2s_out->bck_gpios[i] = options.bck_gpios[i];
+        if (options->bck_gpios[i] > 0) {
+          i2s_out->bck_gpios[i] = options->bck_gpios[i];
 
-          gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[options.bck_gpios[i]], PIN_FUNC_GPIO);
-          gpio_ll_input_disable(&GPIO, options.bck_gpios[i]);
-          gpio_ll_output_enable(&GPIO, options.bck_gpios[i]);
+          gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[options->bck_gpios[i]], PIN_FUNC_GPIO);
+          gpio_ll_input_disable(&GPIO, options->bck_gpios[i]);
+          gpio_ll_output_enable(&GPIO, options->bck_gpios[i]);
 
-          esp_rom_gpio_connect_out_signal(options.bck_gpios[i], i2s_bck_out_sig[i2s_out->port], options.bck_inv, false);
+          esp_rom_gpio_connect_out_signal(options->bck_gpios[i], i2s_bck_out_sig[i2s_out->port], options->bck_inv, false);
         }
 
-        if (options.data_gpios[i] > 0) {
-          i2s_out->data_gpios[i] = options.data_gpios[i];
+        if (options->data_gpios[i] > 0) {
+          i2s_out->data_gpios[i] = options->data_gpios[i];
 
-          gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[options.data_gpios[i]], PIN_FUNC_GPIO);
-          gpio_ll_input_disable(&GPIO, options.data_gpios[i]);
-          gpio_ll_output_enable(&GPIO, options.data_gpios[i]);
+          gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[options->data_gpios[i]], PIN_FUNC_GPIO);
+          gpio_ll_input_disable(&GPIO, options->data_gpios[i]);
+          gpio_ll_output_enable(&GPIO, options->data_gpios[i]);
 
           // data[0] is mapped to the most significant bit, which is OUT7
-          esp_rom_gpio_connect_out_signal(options.data_gpios[i], i2s_parallel8_data_out_sig[i2s_out->port] + 8 - i - 1, false, false);
+          esp_rom_gpio_connect_out_signal(options->data_gpios[i], i2s_parallel8_data_out_sig[i2s_out->port] + 8 - i - 1, false, false);
         }
 
-        if (options.inv_data_gpios[i] > 0) {
-          i2s_out->inv_data_gpios[i] = options.inv_data_gpios[i];
+        if (options->inv_data_gpios[i] > 0) {
+          i2s_out->inv_data_gpios[i] = options->inv_data_gpios[i];
 
-          gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[options.inv_data_gpios[i]], PIN_FUNC_GPIO);
-          gpio_ll_input_disable(&GPIO, options.inv_data_gpios[i]);
-          gpio_ll_output_enable(&GPIO, options.inv_data_gpios[i]);
+          gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[options->inv_data_gpios[i]], PIN_FUNC_GPIO);
+          gpio_ll_input_disable(&GPIO, options->inv_data_gpios[i]);
+          gpio_ll_output_enable(&GPIO, options->inv_data_gpios[i]);
 
           // data[0] is mapped to the most significant bit, which is OUT7
-          esp_rom_gpio_connect_out_signal(options.inv_data_gpios[i], i2s_parallel8_data_out_sig[i2s_out->port] + 8 - i - 1, true, false);
+          esp_rom_gpio_connect_out_signal(options->inv_data_gpios[i], i2s_parallel8_data_out_sig[i2s_out->port] + 8 - i - 1, true, false);
         }
       }
   }

--- a/components/i2s_out/esp8266/dev.c
+++ b/components/i2s_out/esp8266/dev.c
@@ -3,16 +3,16 @@
 #include <logging.h>
 
 // no-op, only one I2S dev which is hardcoded
-int i2s_out_dev_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
+int i2s_out_dev_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options)
 {
-  if (options.dev_mutex) {
-    LOG_DEBUG("take dev_mutex=%p", options.dev_mutex);
+  if (options->dev_mutex) {
+    LOG_DEBUG("take dev_mutex=%p", options->dev_mutex);
 
-    if (!xSemaphoreTake(options.dev_mutex, portMAX_DELAY)) {
+    if (!xSemaphoreTake(options->dev_mutex, portMAX_DELAY)) {
       LOG_ERROR("xSemaphoreTake");
       return -1;
     } else {
-      i2s_out->dev_mutex = options.dev_mutex;
+      i2s_out->dev_mutex = options->dev_mutex;
 
       LOG_DEBUG("have dev_mutex=%p", i2s_out->dev_mutex);
     }

--- a/components/i2s_out/esp8266/dma.c
+++ b/components/i2s_out/esp8266/dma.c
@@ -335,7 +335,6 @@ int i2s_out_dma_write(struct i2s_out *i2s_out, const void *data, size_t size)
     // copy data to desc buf
     LOG_DEBUG("copy len=%u -> ptr=%p", len, ptr);
 
-
     memcpy(ptr, data, len);
 
     i2s_out_dma_commit(i2s_out, len, 1);

--- a/components/i2s_out/esp8266/dma.c
+++ b/components/i2s_out/esp8266/dma.c
@@ -205,17 +205,17 @@ void IRAM_ATTR i2s_out_slc_isr(void *arg)
   slc_intr_clear(&SLC0);
 }
 
-int i2s_out_dma_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
+int i2s_out_dma_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options)
 {
   LOG_DEBUG("...");
 
-  if (options.eof_count * sizeof(options.eof_value) > DMA_EOF_BUF_SIZE) {
-    LOG_ERROR("eof_count=%u is too large for eof buf size=%u", options.eof_count, DMA_EOF_BUF_SIZE);
+  if (options->eof_count * sizeof(options->eof_value) > DMA_EOF_BUF_SIZE) {
+    LOG_ERROR("eof_count=%u is too large for eof buf size=%u", options->eof_count, DMA_EOF_BUF_SIZE);
     return -1;
   }
 
   // init EOF buffer
-  init_dma_eof_desc(i2s_out->dma_eof_desc, options.eof_value, options.eof_count);
+  init_dma_eof_desc(i2s_out->dma_eof_desc, options->eof_value, options->eof_count);
 
   // init RX desc
   reinit_dma_desc(i2s_out->dma_rx_desc, i2s_out->dma_rx_count, i2s_out->dma_eof_desc);

--- a/components/i2s_out/esp8266/i2s.c
+++ b/components/i2s_out/esp8266/i2s.c
@@ -62,7 +62,7 @@ int i2s_out_i2s_setup(struct i2s_out *i2s_out, const struct i2s_out_options *opt
   I2S0.conf.clkm_div_num = options->clock.clkm_div;
   I2S0.conf.bck_div_num = options->clock.bck_div;
 
-  switch (options.mode) {
+  switch (options->mode) {
     case I2S_OUT_MODE_16BIT_SERIAL:
       I2S0.conf.right_first = 0; // TX LEFT, RIGHT
       I2S0.conf.msb_right = 1; // FIFO is RIGHT, LEFT

--- a/components/i2s_out/esp8266/i2s.c
+++ b/components/i2s_out/esp8266/i2s.c
@@ -47,7 +47,7 @@ int i2s_out_i2s_init(struct i2s_out *i2s_out)
   return 0;
 }
 
-int i2s_out_i2s_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
+int i2s_out_i2s_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options)
 {
   taskENTER_CRITICAL();
 
@@ -59,8 +59,8 @@ int i2s_out_i2s_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
 
   I2S0.conf.tx_slave_mod = 0; // generate output clock
   I2S0.conf.rx_slave_mod = 0;
-  I2S0.conf.clkm_div_num = options.clock.clkm_div;
-  I2S0.conf.bck_div_num = options.clock.bck_div;
+  I2S0.conf.clkm_div_num = options->clock.clkm_div;
+  I2S0.conf.bck_div_num = options->clock.bck_div;
 
   switch (options.mode) {
     case I2S_OUT_MODE_16BIT_SERIAL:

--- a/components/i2s_out/esp8266/intr.c
+++ b/components/i2s_out/esp8266/intr.c
@@ -1,6 +1,6 @@
 #include "../i2s_out.h"
 
-int i2s_out_intr_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
+int i2s_out_intr_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options)
 {
   // i2s/dma have separate ISRs
   return 0;

--- a/components/i2s_out/esp8266/pin.c
+++ b/components/i2s_out/esp8266/pin.c
@@ -8,14 +8,14 @@ int i2s_out_pin_init(struct i2s_out *i2s_out)
   return 0;
 }
 
-int i2s_out_pin_setup(struct i2s_out *i2s_out, struct i2s_out_options options)
+int i2s_out_pin_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options)
 {
-  if (options.pin_mutex) {
-    if (!xSemaphoreTake(options.pin_mutex, options.pin_timeout)) {
+  if (options->pin_mutex) {
+    if (!xSemaphoreTake(options->pin_mutex, options->pin_timeout)) {
       LOG_ERROR("xSemaphoreTake");
       return -1;
     } else {
-      i2s_out->pin_mutex = options.pin_mutex;
+      i2s_out->pin_mutex = options->pin_mutex;
     }
   }
 

--- a/components/i2s_out/i2s_out.c
+++ b/components/i2s_out/i2s_out.c
@@ -77,7 +77,7 @@ error:
   return err;
 }
 
-int i2s_out_open(struct i2s_out *i2s_out, struct i2s_out_options options)
+int i2s_out_open(struct i2s_out *i2s_out, const struct i2s_out_options *options)
 {
   int err = 0;
 

--- a/components/i2s_out/i2s_out.c
+++ b/components/i2s_out/i2s_out.c
@@ -161,14 +161,47 @@ int i2s_out_write_serial32(struct i2s_out *i2s_out, const uint32_t data[], size_
 }
 
 #if I2S_OUT_PARALLEL_SUPPORTED
-  int i2s_out_write_parallel8x8(struct i2s_out *i2s_out, uint8_t data[8])
+  int i2s_out_write_parallel8x8(struct i2s_out *i2s_out, uint8_t *data, unsigned width)
   {
-    uint32_t buf[2];
+    int ret = 0;
 
-    // 8x8-bit -> 2x32-bit
-    i2s_out_transpose_parallel8x8(data, buf);
+    if (!xSemaphoreTakeRecursive(i2s_out->mutex, portMAX_DELAY)) {
+      LOG_ERROR("xSemaphoreTakeRecursive");
+      return -1;
+    }
 
-    return i2s_out_write(i2s_out, buf, sizeof(buf));
+    uint32_t (*buf)[2];
+    unsigned index = 0;
+
+    while (index < width) {
+      // get DMA buffer for remaining blocks
+      void *ptr;
+      size_t count;
+
+      if (!(count = i2s_out_dma_buffer(i2s_out, &ptr, width - index, sizeof(*buf)))) {
+        LOG_WARN("i2s_out_dma_buffer: DMA buffer full");
+        ret = 1;
+        goto error;
+      }
+
+      // transpose each 8-bit block -> 2x32-bit buffer that fits into the DMA buffer
+      buf = ptr;
+
+      for (int i = 0; i < count; i++) {
+        LOG_DEBUG("index=%u: buf[%d]=%p ", index, i, buf[i]);
+
+        i2s_out_transpose_parallel8x8(data, width, index++, buf[i]);
+      }
+
+      i2s_out_dma_commit(i2s_out, count, sizeof(*buf));
+    }
+
+error:
+    if (!xSemaphoreGiveRecursive(i2s_out->mutex)) {
+      LOG_ERROR("xSemaphoreGiveRecursive");
+    }
+
+    return ret;
   }
 
   int i2s_out_write_parallel8x16(struct i2s_out *i2s_out, uint16_t *data, unsigned width)

--- a/components/i2s_out/i2s_out.h
+++ b/components/i2s_out/i2s_out.h
@@ -53,7 +53,7 @@ struct i2s_out {
 
 /* dma.c */
 int i2s_out_dma_init(struct i2s_out *i2s_out, size_t size, size_t align);
-int i2s_out_dma_setup(struct i2s_out *i2s_out, struct i2s_out_options options);
+int i2s_out_dma_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options);
 size_t i2s_out_dma_buffer(struct i2s_out *i2s_out, void **ptr, unsigned count, size_t size);
 void i2s_out_dma_commit(struct i2s_out *i2s_out, unsigned count, size_t size);
 int i2s_out_dma_write(struct i2s_out *i2s_out, const void *data, size_t size);
@@ -63,20 +63,20 @@ int i2s_out_dma_flush(struct i2s_out *i2s_out);
 
 /* i2s.c */
 int i2s_out_i2s_init(struct i2s_out *i2s_out);
-int i2s_out_i2s_setup(struct i2s_out *i2s_out, struct i2s_out_options options);
+int i2s_out_i2s_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options);
 void i2s_out_i2s_start(struct i2s_out *i2s_out);
 int i2s_out_i2s_flush(struct i2s_out *i2s_out);
 void i2s_out_i2s_stop(struct i2s_out *i2s_out);
 
 /* dev.c */
-int i2s_out_dev_setup(struct i2s_out *i2s_out, struct i2s_out_options options);
+int i2s_out_dev_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options);
 void i2s_out_dev_teardown(struct i2s_out *i2s_out);
 
 /* pin.c */
 int i2s_out_pin_init(struct i2s_out *i2s_out);
-int i2s_out_pin_setup(struct i2s_out *i2s_out, struct i2s_out_options options);
+int i2s_out_pin_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options);
 void i2s_out_pin_teardown(struct i2s_out *i2s_out);
 
 /* intr.c */
-int i2s_out_intr_setup(struct i2s_out *i2s_out, struct i2s_out_options options);
+int i2s_out_intr_setup(struct i2s_out *i2s_out, const struct i2s_out_options *options);
 void i2s_out_intr_teardown(struct i2s_out *i2s_out);

--- a/components/i2s_out/include/i2s_out.h
+++ b/components/i2s_out/include/i2s_out.h
@@ -148,7 +148,7 @@ int i2s_out_new(struct i2s_out **i2s_outp, i2s_port_t port, size_t buffer_size, 
  *
  * Returns <0 on error, 0 on success.
  */
-int i2s_out_open(struct i2s_out *i2s_out, struct i2s_out_options options);
+int i2s_out_open(struct i2s_out *i2s_out, const struct i2s_out_options *options);
 
 /**
  * Copy exactly `count` 16-bit words from `data` into the internal TX DMA buffer for serial output in little-endian order.

--- a/components/i2s_out/include/i2s_out.h
+++ b/components/i2s_out/include/i2s_out.h
@@ -180,20 +180,21 @@ int i2s_out_write_serial32(struct i2s_out *i2s_out, const uint32_t data[], size_
 
 #if I2S_OUT_PARALLEL_SUPPORTED
   /**
-   * Copy exactly 8 channels of 8-bit `data` into the internal TX DMA buffer, transposing the buffers for
+   * Copy 8 channels of `width` x 8-bit `data` into the internal TX DMA buffer, transposing the buffers for
    * parallel output.
    *
    * This does not yet start the I2S output. The internal TX DMA buffer only fits `buffer_size` bytes.
    * Use `i2s_out_flush()` / `i2s_out_close()` to start the I2S output and empty the TX DMA buffer.
    *
-   * @param data 8-bit data per channel
+   * @param data[8][width] 8-bit data per channel
+   * @param width number of uint8_t values per channel
    *
    * Returns <0 error, 0 on success, >0 if TX buffer is full.
    */
-  int i2s_out_write_parallel8x8(struct i2s_out *i2s_out, uint8_t data[8]);
+  int i2s_out_write_parallel8x8(struct i2s_out *i2s_out, uint8_t *data, unsigned width);
 
   /**
-   * Copy 8 channels of `width` x 16-bit `data`  into the internal TX DMA buffer, transposing the buffers for
+   * Copy 8 channels of `width` x 16-bit `data` into the internal TX DMA buffer, transposing the buffers for
    * parallel output.
    *
    * This does not yet start the I2S output. The internal TX DMA buffer only fits `buffer_size` bytes.

--- a/components/i2s_out/transpose.h
+++ b/components/i2s_out/transpose.h
@@ -1,123 +1,71 @@
-// code adapted from https://github.com/hcs0/Hackers-Delight/blob/master/transpose8.c.txt
-// transpose an array of data[8] parallel 8x8-bit values at [0..8] -> 2x32-bit I2S 8-bit FIFO values at *buf
-static inline void i2s_out_transpose_parallel8x8(const uint8_t data[8], uint32_t buf[2])
+#define UNPACK_UINT32_L(data, step, index, shift) ( \
+    (((data[0 * (step) + (index)] >> (shift)) & 0xff) << 24) \
+  | (((data[1 * (step) + (index)] >> (shift)) & 0xff) << 16) \
+  | (((data[2 * (step) + (index)] >> (shift)) & 0xff) << 8) \
+  | (((data[3 * (step) + (index)] >> (shift)) & 0xff) << 0) \
+)
+#define UNPACK_UINT32_H(data, step, index, shift) ( \
+    (((data[4 * (step) + (index)] >> (shift)) & 0xff) << 24) \
+  | (((data[5 * (step) + (index)] >> (shift)) & 0xff) << 16) \
+  | (((data[6 * (step) + (index)] >> (shift)) & 0xff) << 8) \
+  | (((data[7 * (step) + (index)] >> (shift)) & 0xff) << 0) \
+)
+
+static inline void i2s_out_transpose_uint32(uint32_t *x, uint32_t *y)
 {
-  uint32_t x, y, t;
+  uint32_t t;
 
-  x = (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | (data[3]);
-  y = (data[4] << 24) | (data[5] << 16) | (data[6] << 8) | (data[7]);
+  t = (*x ^ (*x >> 7)) & 0x00AA00AA; *x = *x ^ t ^ (t << 7); \
+  t = (*y ^ (*y >> 7)) & 0x00AA00AA; *y = *y ^ t ^ (t << 7); \
 
-  t = (x ^ (x >> 7)) & 0x00AA00AA; x = x ^ t ^ (t << 7);
-  t = (y ^ (y >> 7)) & 0x00AA00AA; y = y ^ t ^ (t << 7);
+  t = (*x ^ (*x >> 14)) & 0x0000CCCC; *x = *x ^ t ^ (t << 14);
+  t = (*y ^ (*y >> 14)) & 0x0000CCCC; *y = *y ^ t ^ (t << 14);
 
-  t = (x ^ (x >> 14)) & 0x0000CCCC; x = x ^ t ^ (t << 14);
-  t = (y ^ (y >> 14)) & 0x0000CCCC; y = y ^ t ^ (t << 14);
+  t = (*x & 0xF0F0F0F0) | ((*y >> 4) & 0x0F0F0F0F);
+  *y = ((*x << 4) & 0xF0F0F0F0) | (*y & 0x0F0F0F0F);
+  *x = t;
 
-  buf[0] = (x & 0xF0F0F0F0) | ((y >> 4) & 0x0F0F0F0F);
-  buf[1] = ((x << 4) & 0xF0F0F0F0) | (y & 0x0F0F0F0F);
-
-  // swap the 8-bit bytes of each 16-bit half of each 32-bit sample to account for the I2S 8-bit parallel mode fifo quirks
+  // swap the 8-bit bytes of each 16-bit half of the 32-bit sample for the I2S 8-bit parallel fifo mode
   // TODO: is it possible to merge this into the above bit-wrangling?
-  buf[0] = ((buf[0] << 8) & 0xFF00FF00) | ((buf[0] >> 8) & 0x00FF00FF);
-  buf[1] = ((buf[1] << 8) & 0xFF00FF00) | ((buf[1] >> 8) & 0x00FF00FF);
+  *x = ((*x << 8) & 0xFF00FF00) | ((*x >> 8) & 0x00FF00FF);
+  *y = ((*y << 8) & 0xFF00FF00) | ((*y >> 8) & 0x00FF00FF);
+}
+
+// transpose an array of data[8][step] parallel 8x8-bit values at [0..8][index] -> 2x32-bit I2S 8-bit FIFO values at *buf
+static inline void i2s_out_transpose_parallel8x8(const uint8_t data[8], unsigned step, unsigned index, uint32_t buf[2])
+{
+  buf[0] = UNPACK_UINT32_L(data, step, index, 0);
+  buf[1] = UNPACK_UINT32_H(data, step, index, 0);
+
+  i2s_out_transpose_uint32(&buf[0], &buf[1]);
 }
 
 // transpose an array of data[8][step] parallel 8x16-bit values at [0..8][index] -> 4x32-bit I2S 8-bit FIFO values at *buf
 static inline void i2s_out_transpose_parallel8x16(uint16_t data[], unsigned step, unsigned index, uint32_t buf[4])
 {
-  uint32_t a, b, c, d, t;
+  buf[0] = UNPACK_UINT32_L(data, step, index, 8);
+  buf[1] = UNPACK_UINT32_H(data, step, index, 8);
+  buf[2] = UNPACK_UINT32_L(data, step, index, 0);
+  buf[3] = UNPACK_UINT32_H(data, step, index, 0);
 
-  a = ((data[0 * step + index] >> 8) << 24) | ((data[1 * step + index] >> 8) << 16) | ((data[2 * step + index] >> 8) << 8) | (data[3 * step + index] >> 8);
-  b = ((data[4 * step + index] >> 8) << 24) | ((data[5 * step + index] >> 8) << 16) | ((data[6 * step + index] >> 8) << 8) | (data[7 * step + index] >> 8);
-
-  c = ((data[0 * step + index] & 0xff) << 24) | ((data[1 * step + index] & 0xff) << 16) | ((data[2 * step + index] & 0xff) << 8) | (data[3 * step + index] & 0xff);
-  d = ((data[4 * step + index] & 0xff) << 24) | ((data[5 * step + index] & 0xff) << 16) | ((data[6 * step + index] & 0xff) << 8) | (data[7 * step + index] & 0xff);
-
-  t = (a ^ (a >> 7)) & 0x00AA00AA; a = a ^ t ^ (t << 7);
-  t = (b ^ (b >> 7)) & 0x00AA00AA; b = b ^ t ^ (t << 7);
-  t = (c ^ (c >> 7)) & 0x00AA00AA; c = c ^ t ^ (t << 7);
-  t = (d ^ (d >> 7)) & 0x00AA00AA; d = d ^ t ^ (t << 7);
-
-  t = (a ^ (a >> 14)) & 0x0000CCCC; a = a ^ t ^ (t << 14);
-  t = (b ^ (b >> 14)) & 0x0000CCCC; b = b ^ t ^ (t << 14);
-  t = (c ^ (c >> 14)) & 0x0000CCCC; c = c ^ t ^ (t << 14);
-  t = (d ^ (d >> 14)) & 0x0000CCCC; d = d ^ t ^ (t << 14);
-
-  t = (a & 0xF0F0F0F0) | ((b >> 4) & 0x0F0F0F0F);
-  b = ((a << 4) & 0xF0F0F0F0) | (b & 0x0F0F0F0F);
-  a = t;
-
-  t = (c & 0xF0F0F0F0) | ((d >> 4) & 0x0F0F0F0F);
-  d = ((c << 4) & 0xF0F0F0F0) | (d & 0x0F0F0F0F);
-  c = t;
-
-  // swap the 8-bit bytes of each 16-bit half of the 32-bit sample for the I2S 8-bit parallel fifo mode
-  // TODO: is it possible to merge this into the above bit-wrangling?
-  buf[0] = ((a << 8) & 0xFF00FF00) | ((a >> 8) & 0x00FF00FF);
-  buf[1] = ((b << 8) & 0xFF00FF00) | ((b >> 8) & 0x00FF00FF);
-  buf[2] = ((c << 8) & 0xFF00FF00) | ((c >> 8) & 0x00FF00FF);
-  buf[3] = ((d << 8) & 0xFF00FF00) | ((d >> 8) & 0x00FF00FF);
+  i2s_out_transpose_uint32(&buf[0], &buf[1]);
+  i2s_out_transpose_uint32(&buf[2], &buf[3]);
 }
 
 // transpose an array of data[8][step] parallel 8x32-bit values at [0..8][index] -> 8x32-bit I2S 8-bit FIFO values at *buf
 static inline void i2s_out_transpose_parallel8x32(uint32_t data[], unsigned step, unsigned index, uint32_t buf[8])
 {
-  uint32_t a, b, c, d, e, f, g, h, t;
+  buf[0] = UNPACK_UINT32_L(data, step, index, 24);
+  buf[1] = UNPACK_UINT32_H(data, step, index, 24);
+  buf[2] = UNPACK_UINT32_L(data, step, index, 16);
+  buf[3] = UNPACK_UINT32_H(data, step, index, 16);
+  buf[4] = UNPACK_UINT32_L(data, step, index, 8);
+  buf[5] = UNPACK_UINT32_H(data, step, index, 8);
+  buf[6] = UNPACK_UINT32_L(data, step, index, 0);
+  buf[7] = UNPACK_UINT32_H(data, step, index, 0);
 
-  a = (((data[0 * step + index] >> 24) & 0xff) << 24) | (((data[1 * step + index] >> 24) & 0xff) << 16) | (((data[2 * step + index] >> 24) & 0xff) << 8) | (((data[3 * step + index] >> 24) & 0xff) << 0);
-  b = (((data[4 * step + index] >> 24) & 0xff) << 24) | (((data[5 * step + index] >> 24) & 0xff) << 16) | (((data[6 * step + index] >> 24) & 0xff) << 8) | (((data[7 * step + index] >> 24) & 0xff) << 0);
-
-  c = (((data[0 * step + index] >> 16) & 0xff) << 24) | (((data[1 * step + index] >> 16) & 0xff) << 16) | (((data[2 * step + index] >> 16) & 0xff) << 8) | (((data[3 * step + index] >> 16) & 0xff) << 0);
-  d = (((data[4 * step + index] >> 16) & 0xff) << 24) | (((data[5 * step + index] >> 16) & 0xff) << 16) | (((data[6 * step + index] >> 16) & 0xff) << 8) | (((data[7 * step + index] >> 16) & 0xff) << 0);
-
-  e = (((data[0 * step + index] >> 8) & 0xff) << 24) | (((data[1 * step + index] >> 8) & 0xff) << 16) | (((data[2 * step + index] >> 8) & 0xff) << 8) | (((data[3 * step + index] >> 8) & 0xff) << 0);
-  f = (((data[4 * step + index] >> 8) & 0xff) << 24) | (((data[5 * step + index] >> 8) & 0xff) << 16) | (((data[6 * step + index] >> 8) & 0xff) << 8) | (((data[7 * step + index] >> 8) & 0xff) << 0);
-
-  g = (((data[0 * step + index] >> 0) & 0xff) << 24) | (((data[1 * step + index] >> 0) & 0xff) << 16) | (((data[2 * step + index] >> 0) & 0xff) << 8) | (((data[3 * step + index] >> 0) & 0xff) << 0);
-  h = (((data[4 * step + index] >> 0) & 0xff) << 24) | (((data[5 * step + index] >> 0) & 0xff) << 16) | (((data[6 * step + index] >> 0) & 0xff) << 8) | (((data[7 * step + index] >> 0) & 0xff) << 0);
-
-  t = (a ^ (a >> 7)) & 0x00AA00AA; a = a ^ t ^ (t << 7);
-  t = (b ^ (b >> 7)) & 0x00AA00AA; b = b ^ t ^ (t << 7);
-  t = (c ^ (c >> 7)) & 0x00AA00AA; c = c ^ t ^ (t << 7);
-  t = (d ^ (d >> 7)) & 0x00AA00AA; d = d ^ t ^ (t << 7);
-  t = (e ^ (e >> 7)) & 0x00AA00AA; e = e ^ t ^ (t << 7);
-  t = (f ^ (f >> 7)) & 0x00AA00AA; f = f ^ t ^ (t << 7);
-  t = (g ^ (g >> 7)) & 0x00AA00AA; g = g ^ t ^ (t << 7);
-  t = (h ^ (h >> 7)) & 0x00AA00AA; h = h ^ t ^ (t << 7);
-
-  t = (a ^ (a >> 14)) & 0x0000CCCC; a = a ^ t ^ (t << 14);
-  t = (b ^ (b >> 14)) & 0x0000CCCC; b = b ^ t ^ (t << 14);
-  t = (c ^ (c >> 14)) & 0x0000CCCC; c = c ^ t ^ (t << 14);
-  t = (d ^ (d >> 14)) & 0x0000CCCC; d = d ^ t ^ (t << 14);
-  t = (e ^ (e >> 14)) & 0x0000CCCC; e = e ^ t ^ (t << 14);
-  t = (f ^ (f >> 14)) & 0x0000CCCC; f = f ^ t ^ (t << 14);
-  t = (g ^ (g >> 14)) & 0x0000CCCC; g = g ^ t ^ (t << 14);
-  t = (h ^ (h >> 14)) & 0x0000CCCC; h = h ^ t ^ (t << 14);
-
-  t = (a & 0xF0F0F0F0) | ((b >> 4) & 0x0F0F0F0F);
-  b = ((a << 4) & 0xF0F0F0F0) | (b & 0x0F0F0F0F);
-  a = t;
-
-  t = (c & 0xF0F0F0F0) | ((d >> 4) & 0x0F0F0F0F);
-  d = ((c << 4) & 0xF0F0F0F0) | (d & 0x0F0F0F0F);
-  c = t;
-
-  t = (e & 0xF0F0F0F0) | ((f >> 4) & 0x0F0F0F0F);
-  f = ((e << 4) & 0xF0F0F0F0) | (f & 0x0F0F0F0F);
-  e = t;
-
-  t = (g & 0xF0F0F0F0) | ((h >> 4) & 0x0F0F0F0F);
-  h = ((g << 4) & 0xF0F0F0F0) | (h & 0x0F0F0F0F);
-  g = t;
-
-  // swap the 8-bit bytes of each 16-bit half of the 32-bit sample for the I2S 8-bit parallel fifo mode
-  // TODO: is it possible to merge this into the above bit-wrangling?
-  buf[0] = ((a << 8) & 0xFF00FF00) | ((a >> 8) & 0x00FF00FF);
-  buf[1] = ((b << 8) & 0xFF00FF00) | ((b >> 8) & 0x00FF00FF);
-  buf[2] = ((c << 8) & 0xFF00FF00) | ((c >> 8) & 0x00FF00FF);
-  buf[3] = ((d << 8) & 0xFF00FF00) | ((d >> 8) & 0x00FF00FF);
-  buf[4] = ((e << 8) & 0xFF00FF00) | ((e >> 8) & 0x00FF00FF);
-  buf[5] = ((f << 8) & 0xFF00FF00) | ((f >> 8) & 0x00FF00FF);
-  buf[6] = ((g << 8) & 0xFF00FF00) | ((g >> 8) & 0x00FF00FF);
-  buf[7] = ((h << 8) & 0xFF00FF00) | ((h >> 8) & 0x00FF00FF);
+  i2s_out_transpose_uint32(&buf[0], &buf[1]);
+  i2s_out_transpose_uint32(&buf[2], &buf[3]);
+  i2s_out_transpose_uint32(&buf[4], &buf[5]);
+  i2s_out_transpose_uint32(&buf[6], &buf[7]);
 }

--- a/components/leds/interfaces/i2s.h
+++ b/components/leds/interfaces/i2s.h
@@ -5,31 +5,101 @@
 #if CONFIG_LEDS_I2S_ENABLED
 
 enum leds_interface_i2s_mode {
-  LEDS_INTERFACE_I2S_MODE_32BIT_BCK,          // 32-bit with bit-clock, 32-bit start frame + end frame bit per pixel
+  LEDS_INTERFACE_I2S_MODE_32BIT_BCK,          // 32-bit with bit-clock, 32x0-bit start frame + 32x0-bit end frame with at least one bit per pixel
 
   LEDS_INTERFACE_I2S_MODE_24BIT_1U250_4X4_80UL, // 24 bits @ 1.250us/bit, 4-bit symbols * 4-bit LUT, 80us low reset -> uint16_t[6]
   LEDS_INTERFACE_I2S_MODE_32BIT_1U250_4X4_80UL, // 32 bits @ 1.250us/bit, 4-bit symbols * 4-bit LUT, 80us low reset -> uint16_t[8]
 };
 
-struct leds_interface_i2s_tx {
-  void *data;
+#define LEDS_INTERFACE_I2S_MODE_32BIT_BCK_START_FRAME 0x00000000
+
+static inline uint32_t leds_interface_i2s_mode_start_frame(enum leds_interface_i2s_mode mode)
+{
+  switch (mode) {
+    case LEDS_INTERFACE_I2S_MODE_32BIT_BCK:
+      return LEDS_INTERFACE_I2S_MODE_32BIT_BCK_START_FRAME;
+
+    default:
+      abort();
+  }
+}
+
+union leds_interface_i2s_buf {
+  uint32_t i2s_mode_32bit[1];
+  uint16_t i2s_mode_24bit_4x4[6];
+  uint16_t i2s_mode_32bit_4x4[8];
+
+  uint32_t i2s_mode_32bit_parallel8[8][1];
+  uint16_t i2s_mode_24bit_4x4_parallel8[8][6];
+  uint16_t i2s_mode_32bit_4x4_parallel8[8][8];
+};
+
+#define SIZEOF_LEDS_INTERFACE_I2S_BUF(member) sizeof(((union leds_interface_i2s_buf *)(NULL))->member)
+
+static inline size_t leds_interface_i2s_buf_size(enum leds_interface_i2s_mode mode, unsigned parallel)
+{
+  switch(mode) {
+    case LEDS_INTERFACE_I2S_MODE_32BIT_BCK:
+    #if I2S_OUT_PARALLEL_SUPPORTED
+      if (parallel) {
+        return SIZEOF_LEDS_INTERFACE_I2S_BUF(i2s_mode_32bit_parallel8);
+      } else {
+        return SIZEOF_LEDS_INTERFACE_I2S_BUF(i2s_mode_32bit);
+      }
+    #else
+      return SIZEOF_LEDS_INTERFACE_I2S_BUF(i2s_mode_32bit);
+    #endif
+    case LEDS_INTERFACE_I2S_MODE_24BIT_1U250_4X4_80UL:
+    #if I2S_OUT_PARALLEL_SUPPORTED
+      if (parallel) {
+        return SIZEOF_LEDS_INTERFACE_I2S_BUF(i2s_mode_24bit_4x4_parallel8);
+      } else {
+        return SIZEOF_LEDS_INTERFACE_I2S_BUF(i2s_mode_24bit_4x4);
+      }
+    #else
+      return SIZEOF_LEDS_INTERFACE_I2S_BUF(i2s_mode_24bit_4x4);
+    #endif
+    case LEDS_INTERFACE_I2S_MODE_32BIT_1U250_4X4_80UL:
+    #if I2S_OUT_PARALLEL_SUPPORTED
+      if (parallel) {
+        return SIZEOF_LEDS_INTERFACE_I2S_BUF(i2s_mode_32bit_4x4_parallel8);
+      } else {
+        return SIZEOF_LEDS_INTERFACE_I2S_BUF(i2s_mode_32bit_4x4);
+      }
+    #else
+      return SIZEOF_LEDS_INTERFACE_I2S_BUF(i2s_mode_32bit_4x4);
+    #endif
+    default:
+      abort();
+  }
+}
+
+union leds_interface_i2s_func {
+  void (*i2s_mode_32bit)(uint32_t buf[1], void *data, unsigned index, const struct leds_limit *limit);
+  void (*i2s_mode_24bit_4x4)(uint16_t buf[6], void *data, unsigned index, const struct leds_limit *limit);
+  void (*i2s_mode_32bit_4x4)(uint16_t buf[8], void *data, unsigned index, const struct leds_limit *limit);
+};
+
+#define LEDS_INTERFACE_I2S_FUNC(type, func) ((union leds_interface_i2s_func) { .type = func })
+
+struct leds_interface_i2s {
+  enum leds_interface_i2s_mode mode;
+  unsigned parallel;
   unsigned count;
-  const struct leds_limit *limit;
 
-  union {
-    uint32_t i2s_mode_32bit;
-  } start_frame;
+  struct i2s_out *i2s_out;
+  struct i2s_out_options i2s_out_options;
 
-  union {
-    void (*i2s_mode_32bit)(uint32_t buf[1], void *data, unsigned index, const struct leds_limit *limit);
-    void (*i2s_mode_24bit_4x4)(uint16_t buf[6], void *data, unsigned index, const struct leds_limit *limit);
-    void (*i2s_mode_32bit_4x4)(uint16_t buf[8], void *data, unsigned index, const struct leds_limit *limit);
-  } func;
+  struct gpio_options *gpio_options;
+  gpio_pins_t gpio_out_pins;
+
+  union leds_interface_i2s_buf *buf;
 };
 
 size_t leds_interface_i2s_buffer_size(enum leds_interface_i2s_mode mode, unsigned led_count, unsigned pin_count);
 size_t leds_interface_i2s_buffer_align(enum leds_interface_i2s_mode mode, unsigned pin_count);
 
-int leds_interface_i2s_tx(const struct leds_interface_i2s_options *options, enum leds_interface_i2s_mode mode, struct leds_interface_i2s_tx tx);
+int leds_interface_i2s_init(struct leds_interface_i2s *interface, const struct leds_interface_i2s_options *options, enum leds_interface_i2s_mode mode, unsigned count);
+int leds_interface_i2s_tx(struct leds_interface_i2s *interface, union leds_interface_i2s_func func, void *data, const struct leds_limit *limit);
 
 #endif

--- a/components/leds/interfaces/i2s/tx.c
+++ b/components/leds/interfaces/i2s/tx.c
@@ -4,26 +4,24 @@
 
 #include <logging.h>
 
-static int leds_interface_i2s_tx_32bit_bck_serial32(struct i2s_out *i2s_out, struct leds_interface_i2s_tx tx)
+static int leds_interface_i2s_tx_32bit_bck_serial32(struct leds_interface_i2s *interface, union leds_interface_i2s_func func, void *data, const struct leds_limit *limit)
 {
   int err;
 
   // start frame
-  uint32_t start_frame = tx.start_frame.i2s_mode_32bit;
+  uint32_t start_frame = leds_interface_i2s_mode_start_frame(interface->mode);
 
-  if ((err = i2s_out_write_serial32(i2s_out, &start_frame, 1))) {
+  if ((err = i2s_out_write_serial32(interface->i2s_out, &start_frame, 1))) {
     LOG_ERROR("i2s_out_write_serial32");
     return err;
   }
 
   // pixel frames
-  for (unsigned i = 0; i < tx.count; i++) {
-    // transmit in 32-bit little-endian order
-    uint32_t buf[1];
+  for (unsigned i = 0; i < interface->count; i++) {
+    // 32-bit pixel data
+    func.i2s_mode_32bit(interface->buf->i2s_mode_32bit, data, i, limit);
 
-    tx.func.i2s_mode_32bit(buf, tx.data, i, tx.limit);
-
-    if ((err = i2s_out_write_serial32(i2s_out, buf, 1))) {
+    if ((err = i2s_out_write_serial32(interface->i2s_out, interface->buf->i2s_mode_32bit, 1))) {
       LOG_ERROR("i2s_out_write_serial32");
       return err;
     }
@@ -32,16 +30,15 @@ static int leds_interface_i2s_tx_32bit_bck_serial32(struct i2s_out *i2s_out, str
   return 0;
 }
 
-static int leds_interface_i2s_tx_24bit_4x4_serial16(struct i2s_out *i2s_out, struct leds_interface_i2s_tx tx)
+static int leds_interface_i2s_tx_24bit_4x4_serial16(struct leds_interface_i2s *interface, union leds_interface_i2s_func func, void *data, const struct leds_limit *limit)
 {
   int err;
 
-  for (unsigned i = 0; i < tx.count; i++) {
-    uint16_t buf[6];
+  for (unsigned i = 0; i < interface->count; i++) {
+    // 6x16-bit pixel data
+    func.i2s_mode_24bit_4x4(interface->buf->i2s_mode_24bit_4x4, data, i, limit);
 
-    tx.func.i2s_mode_24bit_4x4(buf, tx.data, i, tx.limit);
-
-    if ((err = i2s_out_write_serial16(i2s_out, buf, 6))) {
+    if ((err = i2s_out_write_serial16(interface->i2s_out, interface->buf->i2s_mode_24bit_4x4, 6))) {
       LOG_ERROR("i2s_out_write_serial16");
       return err;
     }
@@ -50,16 +47,15 @@ static int leds_interface_i2s_tx_24bit_4x4_serial16(struct i2s_out *i2s_out, str
   return 0;
 }
 
-static int leds_interface_i2s_tx_32bit_4x4_serial16(struct i2s_out *i2s_out, struct leds_interface_i2s_tx tx)
+static int leds_interface_i2s_tx_32bit_4x4_serial16(struct leds_interface_i2s *interface, union leds_interface_i2s_func func, void *data, const struct leds_limit *limit)
 {
   int err;
 
-  for (unsigned i = 0; i < tx.count; i++) {
-    uint16_t buf[8];
+  for (unsigned i = 0; i < interface->count; i++) {
+    // 8x16-bit pixel data
+    func.i2s_mode_32bit_4x4(interface->buf->i2s_mode_32bit_4x4, data, i, limit);
 
-    tx.func.i2s_mode_32bit_4x4(buf, tx.data, i, tx.limit);
-
-    if ((err = i2s_out_write_serial16(i2s_out, buf, 8))) {
+    if ((err = i2s_out_write_serial16(interface->i2s_out, interface->buf->i2s_mode_32bit_4x4, 8))) {
       LOG_ERROR("i2s_out_write_serial16");
       return err;
     }
@@ -69,28 +65,26 @@ static int leds_interface_i2s_tx_32bit_4x4_serial16(struct i2s_out *i2s_out, str
 }
 
 #if I2S_OUT_PARALLEL_SUPPORTED
-  static int leds_interface_i2s_tx_32bit_bck_parallel8(struct i2s_out *i2s_out, struct leds_interface_i2s_tx tx, unsigned parallel)
+  static int leds_interface_i2s_tx_32bit_bck_parallel8(struct leds_interface_i2s *interface, union leds_interface_i2s_func func, void *data, const struct leds_limit *limit)
   {
-    unsigned length = tx.count / parallel;
+    unsigned length = interface->count / interface->parallel;
     int err;
 
     // start frame
-    uint32_t start_frame[8] = { [0 ... 7] = tx.start_frame.i2s_mode_32bit };
+    uint32_t start_frame[8] = { [0 ... 7] = leds_interface_i2s_mode_start_frame(interface->mode) };
 
-    if ((err = i2s_out_write_parallel8x32(i2s_out, start_frame, 1))) {
+    if ((err = i2s_out_write_parallel8x32(interface->i2s_out, start_frame, 1))) {
       LOG_ERROR("i2s_out_write_parallel8x32");
       return err;
     }
 
     for (unsigned i = 0; i < length; i++) {
       // 8 sets of 32-bit pixel data
-      uint32_t buf[8][1] = {};
-
-      for (unsigned j = 0; j < parallel && j < 8; j++) {
-        tx.func.i2s_mode_32bit(buf[j], tx.data, j * length + i, tx.limit);
+      for (unsigned j = 0; j < interface->parallel && j < 8; j++) {
+        func.i2s_mode_32bit(interface->buf->i2s_mode_32bit_parallel8[j], data, j * length + i, limit);
       }
 
-      if ((err = i2s_out_write_parallel8x32(i2s_out, (uint32_t *) buf, 1))) {
+      if ((err = i2s_out_write_parallel8x32(interface->i2s_out, (uint32_t *) interface->buf->i2s_mode_32bit_parallel8, 1))) {
         LOG_ERROR("i2s_out_write_parallel8x32");
         return err;
       }
@@ -99,20 +93,18 @@ static int leds_interface_i2s_tx_32bit_4x4_serial16(struct i2s_out *i2s_out, str
     return 0;
   }
 
-  static int leds_interface_i2s_tx_24bit_4x4_parallel8(struct i2s_out *i2s_out, struct leds_interface_i2s_tx tx, unsigned parallel)
+  static int leds_interface_i2s_tx_24bit_4x4_parallel8(struct leds_interface_i2s *interface, union leds_interface_i2s_func func, void *data, const struct leds_limit *limit)
   {
-    unsigned length = tx.count / parallel;
+    unsigned length = interface->count / interface->parallel;
     int err;
 
     for (unsigned i = 0; i < length; i++) {
       // 8 sets of 6x16-bit pixel data
-      uint16_t buf[8][6] = {};
-
-      for (unsigned j = 0; j < parallel && j < 8; j++) {
-        tx.func.i2s_mode_24bit_4x4(buf[j], tx.data, j * length + i, tx.limit);
+      for (unsigned j = 0; j < interface->parallel && j < 8; j++) {
+        func.i2s_mode_24bit_4x4(interface->buf->i2s_mode_24bit_4x4_parallel8[j], data, j * length + i, limit);
       }
 
-      if ((err = i2s_out_write_parallel8x16(i2s_out, (uint16_t *) buf, 6))) {
+      if ((err = i2s_out_write_parallel8x16(interface->i2s_out, (uint16_t *) interface->buf->i2s_mode_24bit_4x4_parallel8, 6))) {
         LOG_ERROR("i2s_out_write_parallel8x16");
         return err;
       }
@@ -121,20 +113,18 @@ static int leds_interface_i2s_tx_32bit_4x4_serial16(struct i2s_out *i2s_out, str
     return 0;
   }
 
-  static int leds_interface_i2s_tx_32bit_4x4_parallel8(struct i2s_out *i2s_out, struct leds_interface_i2s_tx tx, unsigned parallel)
+  static int leds_interface_i2s_tx_32bit_4x4_parallel8(struct leds_interface_i2s *interface, union leds_interface_i2s_func func, void *data, const struct leds_limit *limit)
   {
-    unsigned length = tx.count / parallel;
+    unsigned length = interface->count / interface->parallel;
     int err;
 
     for (unsigned i = 0; i < length; i++) {
       // 8 sets of 8x16-bit pixel data
-      uint16_t buf[8][8] = {};
-
-      for (unsigned j = 0; j < parallel && j < 8; j++) {
-        tx.func.i2s_mode_32bit_4x4(buf[j], tx.data, j * length + i, tx.limit);
+      for (unsigned j = 0; j < interface->parallel && j < 8; j++) {
+        func.i2s_mode_32bit_4x4(interface->buf->i2s_mode_32bit_4x4_parallel8[j], data, j * length + i, limit);
       }
 
-      if ((err = i2s_out_write_parallel8x16(i2s_out, (uint16_t *) buf, 8))) {
+      if ((err = i2s_out_write_parallel8x16(interface->i2s_out, (uint16_t *) interface->buf->i2s_mode_32bit_4x4_parallel8, 8))) {
         LOG_ERROR("i2s_out_write_parallel8x16");
         return err;
       }
@@ -144,52 +134,60 @@ static int leds_interface_i2s_tx_32bit_4x4_serial16(struct i2s_out *i2s_out, str
   }
 #endif
 
-static int leds_interface_i2s_tx_write(struct i2s_out *i2s_out, enum leds_interface_i2s_mode mode, struct leds_interface_i2s_tx tx, unsigned parallel)
+static int leds_interface_i2s_tx_write(struct leds_interface_i2s *interface, union leds_interface_i2s_func func, void *data, const struct leds_limit *limit)
 {
-  switch(mode) {
+  switch(interface->mode) {
     case LEDS_INTERFACE_I2S_MODE_32BIT_BCK:
     #if I2S_OUT_PARALLEL_SUPPORTED
-      if (parallel) {
-        return leds_interface_i2s_tx_32bit_bck_parallel8(i2s_out, tx, parallel);
+      if (interface->parallel) {
+        return leds_interface_i2s_tx_32bit_bck_parallel8(interface, func, data, limit);
       } else {
-        return leds_interface_i2s_tx_32bit_bck_serial32(i2s_out, tx);
+        return leds_interface_i2s_tx_32bit_bck_serial32(interface, func, data, limit);
       }
     #else
-      return leds_interface_i2s_tx_32bit_bck_serial32(i2s_out, tx);
+      return leds_interface_i2s_tx_32bit_bck_serial32(interface, func, data, limit);
     #endif
 
     case LEDS_INTERFACE_I2S_MODE_24BIT_1U250_4X4_80UL:
     #if I2S_OUT_PARALLEL_SUPPORTED
-      if (parallel) {
-        return leds_interface_i2s_tx_24bit_4x4_parallel8(i2s_out, tx, parallel);
+      if (interface->parallel) {
+        return leds_interface_i2s_tx_24bit_4x4_parallel8(interface, func, data, limit);
       } else {
-        return leds_interface_i2s_tx_24bit_4x4_serial16(i2s_out, tx);
+        return leds_interface_i2s_tx_24bit_4x4_serial16(interface, func, data, limit);
       }
     #else
-      return leds_interface_i2s_tx_24bit_4x4_serial16(i2s_out, tx);
+      return leds_interface_i2s_tx_24bit_4x4_serial16(interface, func, data, limit);
     #endif
 
     case LEDS_INTERFACE_I2S_MODE_32BIT_1U250_4X4_80UL:
     #if I2S_OUT_PARALLEL_SUPPORTED
-      if (parallel) {
-        return leds_interface_i2s_tx_32bit_4x4_parallel8(i2s_out, tx, parallel);
+      if (interface->parallel) {
+        return leds_interface_i2s_tx_32bit_4x4_parallel8(interface, func, data, limit);
       } else {
-        return leds_interface_i2s_tx_32bit_4x4_serial16(i2s_out, tx);
+        return leds_interface_i2s_tx_32bit_4x4_serial16(interface, func, data, limit);
       }
     #else
-      return leds_interface_i2s_tx_32bit_4x4_serial16(i2s_out, tx);
+      return leds_interface_i2s_tx_32bit_4x4_serial16(interface, func, data, limit);
     #endif
 
     default:
-      LOG_ERROR("unknown mode=%08x", mode);
+      LOG_ERROR("unknown mode=%08x", interface->mode);
       return -1;
   }
 }
 
-int leds_interface_i2s_tx(const struct leds_interface_i2s_options *options, enum leds_interface_i2s_mode mode, struct leds_interface_i2s_tx tx)
+int leds_interface_i2s_init(struct leds_interface_i2s *interface, const struct leds_interface_i2s_options *options, enum leds_interface_i2s_mode mode, unsigned count)
 {
-  struct leds_interface_i2s_stats *stats = &leds_interface_stats.i2s;
-  struct i2s_out_options i2s_out_options = {
+  interface->mode = mode;
+  interface->count = count;
+#if LEDS_I2S_DATA_PINS_ENABLED
+  interface->parallel = options->data_pins_count;
+#else
+  interface->parallel = 0;
+#endif
+
+  interface->i2s_out = options->i2s_out;
+  interface->i2s_out_options = (struct i2s_out_options) {
     // shared IO pins
     .pin_mutex    = options->pin_mutex,
     .pin_timeout  = options->pin_timeout,
@@ -199,24 +197,18 @@ int leds_interface_i2s_tx(const struct leds_interface_i2s_options *options, enum
     .inv_data_gpio  = options->inv_data_pin,
 #endif
   };
-#if LEDS_I2S_DATA_PINS_ENABLED
-  unsigned parallel = options->data_pins_count;
-#else
-  unsigned parallel = 0;
-#endif
-  int err;
 
   switch(mode) {
     case LEDS_INTERFACE_I2S_MODE_32BIT_BCK:
     #if LEDS_I2S_DATA_PINS_ENABLED
-      if (options->data_pins_count) {
-        i2s_out_options.mode = I2S_OUT_MODE_8BIT_PARALLEL;
+      if (interface->parallel) {
+        interface->i2s_out_options.mode = I2S_OUT_MODE_8BIT_PARALLEL;
       } else {
         // raw 32-bit samples
-        i2s_out_options.mode = I2S_OUT_MODE_32BIT_SERIAL;
+        interface->i2s_out_options.mode = I2S_OUT_MODE_32BIT_SERIAL;
       }
     #else
-      i2s_out_options.mode = I2S_OUT_MODE_32BIT_SERIAL;
+      interface->i2s_out_options.mode = I2S_OUT_MODE_32BIT_SERIAL;
     #endif
 
       break;
@@ -224,14 +216,14 @@ int leds_interface_i2s_tx(const struct leds_interface_i2s_options *options, enum
     case LEDS_INTERFACE_I2S_MODE_24BIT_1U250_4X4_80UL:
     case LEDS_INTERFACE_I2S_MODE_32BIT_1U250_4X4_80UL:
     #if LEDS_I2S_DATA_PINS_ENABLED
-      if (options->data_pins_count) {
-        i2s_out_options.mode = I2S_OUT_MODE_8BIT_PARALLEL;
+      if (interface->parallel) {
+        interface->i2s_out_options.mode = I2S_OUT_MODE_8BIT_PARALLEL;
       } else {
         // using 4x4bit -> 16-bit samples
-        i2s_out_options.mode = I2S_OUT_MODE_16BIT_SERIAL;
+        interface->i2s_out_options.mode = I2S_OUT_MODE_16BIT_SERIAL;
       }
     #else
-      i2s_out_options.mode = I2S_OUT_MODE_16BIT_SERIAL;
+      interface->i2s_out_options.mode = I2S_OUT_MODE_16BIT_SERIAL;
     #endif
 
       break;
@@ -239,7 +231,7 @@ int leds_interface_i2s_tx(const struct leds_interface_i2s_options *options, enum
 
   switch(mode) {
     case LEDS_INTERFACE_I2S_MODE_32BIT_BCK:
-      i2s_out_options.clock = i2s_out_clock(options->clock_rate);
+      interface->i2s_out_options.clock = i2s_out_clock(options->clock_rate);
 
       break;
 
@@ -247,7 +239,7 @@ int leds_interface_i2s_tx(const struct leds_interface_i2s_options *options, enum
     case LEDS_INTERFACE_I2S_MODE_32BIT_1U250_4X4_80UL:
       // 3.2MHz bit clock => 0.3125us per I2S bit
       // four I2S bits per 1.25us protocol bit
-      i2s_out_options.clock = I2S_OUT_CLOCK_3M2;
+      interface->i2s_out_options.clock = I2S_OUT_CLOCK_3M2;
 
       break;
   }
@@ -255,63 +247,79 @@ int leds_interface_i2s_tx(const struct leds_interface_i2s_options *options, enum
   switch(mode) {
     case LEDS_INTERFACE_I2S_MODE_32BIT_BCK:
       // XXX: required to workaround I2S start glitch looping previous data bits
-      i2s_out_options.eof_value = 0x00000000;
+      interface->i2s_out_options.eof_value = 0x00000000;
 
       // one clock cycle per pixel, min 32 cycles
-      i2s_out_options.eof_count = (1 + tx.count / 32);
+      interface->i2s_out_options.eof_count = (1 + interface->count / 32);
 
       break;
 
     case LEDS_INTERFACE_I2S_MODE_24BIT_1U250_4X4_80UL:
     case LEDS_INTERFACE_I2S_MODE_32BIT_1U250_4X4_80UL:
       // 1.25us per 4-bit = 2.5us per byte * four bytes per I2S sample = 10us per 32-bit I2S sample
-      i2s_out_options.eof_value = 0x00000000;
+      interface->i2s_out_options.eof_value = 0x00000000;
 
       // hold low for 8 * 10us
-      i2s_out_options.eof_count = 8;
+      interface->i2s_out_options.eof_count = 8;
 
       break;
   }
 
 #if LEDS_I2S_DATA_PINS_ENABLED
-  if (options->data_pins_count) {
+  if (interface->parallel) {
     for (int i = 0; i < I2S_OUT_PARALLEL_SIZE; i++) {
-      i2s_out_options.bck_gpios[i] = (i < options->data_pins_count && i < LEDS_I2S_DATA_PINS_SIZE) ? options->clock_pins[i] : GPIO_NUM_NC;
-      i2s_out_options.data_gpios[i] = (i < options->data_pins_count && i < LEDS_I2S_DATA_PINS_SIZE) ? options->data_pins[i] : GPIO_NUM_NC;
-      i2s_out_options.inv_data_gpios[i] = (i < options->data_pins_count && i < LEDS_I2S_DATA_PINS_SIZE) ? options->inv_data_pins[i] : GPIO_NUM_NC;
+      interface->i2s_out_options.bck_gpios[i] = (i < options->data_pins_count && i < LEDS_I2S_DATA_PINS_SIZE) ? options->clock_pins[i] : GPIO_NUM_NC;
+      interface->i2s_out_options.data_gpios[i] = (i < options->data_pins_count && i < LEDS_I2S_DATA_PINS_SIZE) ? options->data_pins[i] : GPIO_NUM_NC;
+      interface->i2s_out_options.inv_data_gpios[i] = (i < options->data_pins_count && i < LEDS_I2S_DATA_PINS_SIZE) ? options->inv_data_pins[i] : GPIO_NUM_NC;
     }
   } else {
-    i2s_out_options.bck_gpio = options->clock_pin;
-    i2s_out_options.data_gpio = options->data_pin;
-    i2s_out_options.inv_data_gpio = options->inv_data_pin;
+    interface->i2s_out_options.bck_gpio = options->clock_pin;
+    interface->i2s_out_options.data_gpio = options->data_pin;
+    interface->i2s_out_options.inv_data_gpio = options->inv_data_pin;
   }
 #elif LEDS_I2S_GPIO_PINS_ENABLED
-  i2s_out_options.bck_gpio = options->clock_pin;
-  i2s_out_options.data_gpio = options->data_pin;
-  i2s_out_options.inv_data_gpio = options->inv_data_pin;
+  interface->i2s_out_options.bck_gpio = options->clock_pin;
+  interface->i2s_out_options.data_gpio = options->data_pin;
+  interface->i2s_out_options.inv_data_gpio = options->inv_data_pin;
 #endif
 
+  interface->gpio_options = options->gpio.gpio_options;
+  interface->gpio_out_pins = options->gpio.gpio_out_pins;
+
+  if (!(interface->buf = calloc(1, leds_interface_i2s_buf_size(interface->mode, interface->parallel)))) {
+    LOG_ERROR("calloc");
+    return -1;
+  }
+
+  return 0;
+}
+
+int leds_interface_i2s_tx(struct leds_interface_i2s *interface, union leds_interface_i2s_func func, void *data, const struct leds_limit *limit)
+{
+  struct leds_interface_i2s_stats *stats = &leds_interface_stats.i2s;
+  int err;
+
   WITH_STATS_TIMER(&stats->open) {
-    if ((err = i2s_out_open(options->i2s_out, i2s_out_options))) {
+    if ((err = i2s_out_open(interface->i2s_out, &interface->i2s_out_options))) {
       LOG_ERROR("i2s_out_open");
       return err;
     }
   }
 
 #if CONFIG_LEDS_GPIO_ENABLED
-  if (options->gpio.gpio_options) {
-    gpio_out_set(options->gpio.gpio_options, options->gpio.gpio_out_pins);
+  if (interface->gpio_options) {
+    gpio_out_set(interface->gpio_options, interface->gpio_out_pins);
   }
 #endif
 
   WITH_STATS_TIMER(&stats->write) {
-    if ((err = leds_interface_i2s_tx_write(options->i2s_out, mode, tx, parallel))) {
+    if ((err = leds_interface_i2s_tx_write(interface, func, data, limit))) {
       goto error;
     }
   }
 
   WITH_STATS_TIMER(&stats->flush) {
-    if ((err = i2s_out_flush(options->i2s_out))) {
+    if ((err = i2s_out_flush(interface->i2s_out))) {
       LOG_ERROR("i2s_out_flush");
       goto error;
     }
@@ -319,12 +327,12 @@ int leds_interface_i2s_tx(const struct leds_interface_i2s_options *options, enum
 
 error:
 #if CONFIG_LEDS_GPIO_ENABLED
-  if (options->gpio.gpio_options) {
-    gpio_out_clear(options->gpio.gpio_options);
+  if (interface->gpio_options) {
+    gpio_out_clear(interface->gpio_options);
   }
 #endif
 
-  if ((err = i2s_out_close(options->i2s_out))) {
+  if ((err = i2s_out_close(interface->i2s_out))) {
     LOG_ERROR("i2s_out_close");
     return err;
   }

--- a/components/leds/leds.h
+++ b/components/leds/leds.h
@@ -7,6 +7,9 @@
 #if CONFIG_LEDS_SPI_ENABLED
 # include "interfaces/spi.h"
 #endif
+#if CONFIG_LEDS_I2S_ENABLED
+# include "interfaces/i2s.h"
+#endif
 
 #include "protocol.h"
 #include "protocols/apa102.h"
@@ -19,6 +22,9 @@
 union leds_interface_state {
 #if CONFIG_LEDS_SPI_ENABLED
   struct leds_interface_spi spi;
+#endif
+#if CONFIG_LEDS_I2S_ENABLED
+  struct leds_interface_i2s i2s;
 #endif
 };
 

--- a/components/leds/protocols/sk9822.h
+++ b/components/leds/protocols/sk9822.h
@@ -19,13 +19,6 @@ union __attribute__((packed)) sk9822_pixel {
   uint32_t xbgr;
 };
 
-// one frame of 0-bits
-#define SK9822_START_FRAME_UINT32 (uint32_t) 0x00000000
-
-// one bit per LED, in frames of 32 bits
-#define SK9822_END_FRAME_UINT32 (uint32_t) 0x00000000
-#define SK9822_END_FRAME_COUNT(count) (1 + count / 32)
-
 #define LEDS_PROTOCOL_SK9822_INTERFACE_I2S_MODE LEDS_INTERFACE_I2S_MODE_32BIT_BCK
 
 #define SK9822_PIXEL_POWER_DIVISOR (3 * 255 * 31) // one pixel at full brightness

--- a/components/leds/protocols/ws2811.c
+++ b/components/leds/protocols/ws2811.c
@@ -54,12 +54,33 @@ static void leds_protocol_ws2811_i2s_out(uint16_t buf[6], void *data, unsigned i
 
 int leds_protocol_ws2811_init(struct leds_protocol_ws2811 *protocol, union leds_interface_state *interface, const struct leds_options *options)
 {
+  int err;
+
   if (!(protocol->pixels = calloc(options->count, sizeof(*protocol->pixels)))) {
     LOG_ERROR("malloc");
     return -1;
   }
 
   protocol->count = options->count;
+
+  switch (options->interface) {
+    case LEDS_INTERFACE_NONE:
+      break;
+
+  #if CONFIG_LEDS_I2S_ENABLED
+    case LEDS_INTERFACE_I2S:
+      if ((err = leds_interface_i2s_init(&interface->i2s, &options->i2s, LEDS_INTERFACE_I2S_MODE_24BIT_1U250_4X4_80UL, protocol->count))) {
+        LOG_ERROR("leds_interface_i2s_init");
+        return err;
+      }
+
+      break;
+  #endif
+
+    default:
+      LOG_ERROR("unsupported interface=%#x", options->interface);
+      return -1;
+  }
 
   return 0;
 }
@@ -77,13 +98,7 @@ int leds_protocol_ws2811_tx(struct leds_protocol_ws2811 *protocol, union leds_in
 
   #if CONFIG_LEDS_I2S_ENABLED
     case LEDS_INTERFACE_I2S:
-      return leds_interface_i2s_tx(&options->i2s, LEDS_INTERFACE_I2S_MODE_24BIT_1U250_4X4_80UL, (struct leds_interface_i2s_tx) {
-        .data   = protocol->pixels,
-        .count  = protocol->count,
-        .limit  = limit,
-
-        .func.i2s_mode_24bit_4x4 = leds_protocol_ws2811_i2s_out,
-      });
+      return leds_interface_i2s_tx(&interface->i2s, LEDS_INTERFACE_I2S_FUNC(i2s_mode_24bit_4x4, leds_protocol_ws2811_i2s_out), protocol->pixels, limit);
   #endif
 
     default:


### PR DESCRIPTION
Move the `struct i2s_out_options` and and leds i2s interface buffers onto the heap.

Refactor the i2s transpose functions to cleanup the copy-pasta and operate directly on the DMA buffer, saving a negligible amount of stack memory.

Incompatible leds protocl/interface combinations will now error out immediately at `leds_new()`, not later at `leds_tx()`.

Fixes stack overflow on any leds -> i2s_out tx path `LOG_*` printf usage with a 2KB stack:

```
> W (6138) on_user_test_input: trigger
I (6138) trigger_leds_test: mode=1 auto=0
I (6138) leds_artnet_test_select: test start mode=1
I (6138) leds_artnet_test_frame: test mode=1
I (6138) i2s_out_dma_commit: l
***ERROR*** A stack overflow in task leds1 has been detected.


Backtrace:0x40081dd6:0x3ffd61e00x4008ab11:0x3ffd6200 0x4008f57e:0x3ffd6220 0x4008c94a:0x3ffd62a0 0x4008ac10:0x3ffd62c0 0x4008abc2:0x00000014  |<-CORRUPTED
0x40081dd6: panic_abort at /opt/esp-idf/components/esp_system/panic.c:402

0x4008ab11: esp_system_abort at /opt/esp-idf/components/esp_system/esp_system.c:121

0x4008f57e: vApplicationStackOverflowHook at /opt/esp-idf/components/freertos/port/xtensa/port.c:394

0x4008c94a: vTaskSwitchContext at /opt/esp-idf/components/freertos/tasks.c:3505

0x4008ac10: _frxt_dispatch at /opt/esp-idf/components/freertos/port/xtensa/portasm.S:436

0x4008abc2: _frxt_int_exit at /opt/esp-idf/components/freertos/port/xtensa/portasm.S:231
```