### PR TITLE
gpio i2c: skip intr setup if i2c setup fails

### DIFF
--- a/components/gpio/i2c.c
+++ b/components/gpio/i2c.c
@@ -88,9 +88,25 @@
 
   int gpio_i2c_setup(const struct gpio_options *options)
   {
+    int err;
+
     if (!options->i2c_dev) {
       LOG_ERROR("Invalid i2c_dev=NULL");
       return -1;
+    }
+
+    switch(options->i2c_dev->options.type) {
+      case GPIO_I2C_TYPE_PCA9534:
+      case GPIO_I2C_TYPE_PCA9554:
+        if ((err = gpio_i2c_pca54xx_setup(options))) {
+          LOG_ERROR("gpio_i2c_pca54xx_setup");
+          return err;
+        }
+
+        break;
+
+      default:
+        LOG_FATAL("unsupported type=%d", options->i2c_dev->options.type);
     }
 
     if (options->interrupt_pins) {
@@ -109,14 +125,7 @@
       }
     }
 
-    switch(options->i2c_dev->options.type) {
-      case GPIO_I2C_TYPE_PCA9534:
-      case GPIO_I2C_TYPE_PCA9554:
-        return gpio_i2c_pca54xx_setup(options);
-
-      default:
-        LOG_FATAL("unsupported type=%d", options->i2c_dev->options.type);
-    }
+    return 0;
   }
 
   int gpio_i2c_setup_input(const struct gpio_options *options, gpio_pins_t pins)


### PR DESCRIPTION
Fixes crash in user_leds gpio intr handler if gpio I2C setup fails (no I2C GPIO expander connected).

```
E (658) gpio_i2c_pca54xx_write: i2c_master_write_to_device port=0 addr=32: ESP_FAIL
E (658) gpio_i2c_pca54xx_output: gpio_i2c_pca54xx_write
E (668) gpio_i2c_pca54xx_setup: gpio_i2c_pca54xx_output
E (678) user_leds_gpio_init: gpio_setup
E (678) user_leds_new: user_leds_gpio_init
E (688) init_user_leds: user_leds_new
E (688) app_main: init_user_leds
```

```
Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.

Core  0 register dump:
PC      : 0x400835ee  PS      : 0x00060031  A0      : 0x80089140  A1      : 0x3ffb0ad0  
0x400835ee: user_leds_gpio_interrupt at /build/components/user_leds/gpio.c:16

A2      : 0x000000c0  A3      : 0x00000000  A4      : 0x3ffbd460  A5      : 0x00000000  
A6      : 0x00000000  A7      : 0x000000c0  A8      : 0x00000000  A9      : 0x3ff46094  
A10     : 0x3ffae0c4  A11     : 0x0000000a  A12     : 0x3ffc51d0  A13     : 0x3ffc51b0  
A14     : 0x000908fc  A15     : 0x00000002  SAR     : 0x00000004  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x00000008  LBEG    : 0x4000c2e0  LEND    : 0x4000c2f6  LCOUNT  : 0x00000000  


Backtrace: 0x400835eb:0x3ffb0ad0 0x4008913d:0x3ffb0b00 0x400836ce:0x3ffb0b20 0x4008306d:0x3ffb0b40 0x4000bfed:0x3ffc5140 0x4008f95e:0x3ffc5150 0x401026e2:0x3ffc5170 0x400d43df:0x3ffc5190 0x4016f925:0x3ffc51b0 0x4016fa72:0x3ffc51d0 0x40162ef2:0x3ffc51f0 0x40163fe1:0x3ffc5210 0x40161bf8:0x3ffc5240 0x4016267a:0x3ffc5260 0x4014f713:0x3ffc5290 0x4014f7cd:0x3ffc52c0 0x40136032:0x3ffc52e0 0x401367ad:0x3ffc5300 0x40135060:0x3ffc5320 0x40095829:0x3ffc5340 0x4008f6ad:0x3ffc5370
0x400835eb: user_leds_gpio_interrupt at /build/components/user_leds/gpio.c:14

0x4008913d: gpio_i2c_intr_handler at /build/components/gpio/i2c.c:24

0x400836ce: gpio_isr at /build/components/gpio/esp32/gpio_intr.c:33

0x4008306d: _xt_lowint1 at /opt/esp-idf/components/freertos/port/xtensa/xtensa_vectors.S:1114

0x4008f95e: vPortClearInterruptMaskFromISR at /opt/esp-idf/components/freertos/port/xtensa/include/freertos/portmacro.h:571
 (inlined by) vPortExitCritical at /opt/esp-idf/components/freertos/port/xtensa/port.c:332

0x401026e2: adc_power_acquire at /opt/esp-idf/components/driver/adc_common.c:154

0x400d43df: set_xpd_sar at /opt/esp-idf/components/esp_phy/src/phy_override.c:35

0x4016f925: pwdet_sar2_init at /home/cff/gittree/chip7.1_phy/chip_7.1/board_code/app_test/pp/phy/phy_chip_v7_cal.c:194

0x4016fa72: ram_en_pwdet at /home/cff/gittree/chip7.1_phy/chip_7.1/board_code/app_test/pp/phy/phy_chip_v7_cal.c:218

0x40162ef2: txcal_debuge_mode at /home/cff/gittree/chip7.1_phy/chip_7.1/board_code/app_test/pp/phy/phy_chip_v7_cal.c:228

0x40163fe1: tx_cap_init at /home/cff/gittree/chip7.1_phy/chip_7.1/board_code/app_test/pp/phy/phy_chip_v7_cal.c:1198

0x40161bf8: bb_init at /home/cff/gittree/chip7.1_phy/chip_7.1/board_code/app_test/pp/phy/phy_chip_v7.c:2772

0x4016267a: register_chipv7_phy at /home/cff/gittree/chip7.1_phy/chip_7.1/board_code/app_test/pp/phy/phy_chip_v7.c:3782

0x4014f713: esp_phy_load_cal_and_init at /opt/esp-idf/components/esp_phy/src/phy_init.c:722

0x4014f7cd: esp_phy_enable at /opt/esp-idf/components/esp_phy/src/phy_init.c:236

0x40136032: wifi_hw_start at ??:?

0x401367ad: wifi_start_process at ??:?

0x40135060: ieee80211_ioctl_process at ??:?

0x40095829: ppTask at ??:?

0x4008f6ad: vPortTaskWrapper at /opt/esp-idf/components/freertos/port/xtensa/port.c:142

```