### PR TITLE
config save/load changes

### DIFF
--- a/components/config/cmd.c
+++ b/components/config/cmd.c
@@ -189,6 +189,8 @@ int config_cmd_load(int argc, char **argv, void *ctx)
     return -CMD_ERR;
   }
 
+  LOG_WARN("config modified, use `config save` and reboot");
+
   return 0;
 }
 
@@ -337,7 +339,7 @@ int config_cmd_set(int argc, char **argv, void *ctx)
     }
   }
 
-  LOG_WARN("config modified, use `config save`");
+  LOG_WARN("config modified, use `config save` and reboot");
 
   return 0;
 }
@@ -368,7 +370,7 @@ int config_cmd_clear(int argc, char **argv, void *ctx)
     return -CMD_ERR_ARGV;
   }
 
-  LOG_WARN("config modified, use `config save`");
+  LOG_WARN("config modified, use `config save` and reboot");
 
   return 0;
 }

--- a/components/config/cmd.c
+++ b/components/config/cmd.c
@@ -156,6 +156,18 @@ static void print_config(const struct config *config)
   }
 }
 
+int config_cmd_save(int argc, char **argv, void *ctx)
+{
+  struct config *config = ctx;
+
+  if (config_save(config)) {
+    LOG_ERROR("config_save");
+    return -CMD_ERR;
+  }
+
+  return 0;
+}
+
 int config_cmd_load(int argc, char **argv, void *ctx)
 {
   struct config *config = ctx;
@@ -331,6 +343,7 @@ int config_cmd_reset(int argc, char **argv, void *ctx)
 }
 
 const struct cmd config_commands[] = {
+  { "save",              config_cmd_save,   .usage = "",                                .describe = "Save config to filesystem"  },
   { "load",              config_cmd_load,   .usage = "",                                .describe = "Load config from filesystem"  },
   { "show",              config_cmd_show,   .usage = "[SECTION]",                       .describe = "Show config settings"  },
   { "get",               config_cmd_get,    .usage = "SECTION NAME",                    .describe = "Get config setting"    },

--- a/components/config/cmd.c
+++ b/components/config/cmd.c
@@ -192,6 +192,25 @@ int config_cmd_load(int argc, char **argv, void *ctx)
   return 0;
 }
 
+static int print_config_file(const char *filename, void *ctx)
+{
+  printf("%s\n", filename);
+
+  return 0;
+}
+
+int config_cmd_list(int argc, char **argv, void *ctx)
+{
+  struct config *config = ctx;
+
+  if (config_walk(config, print_config_file, NULL)) {
+    LOG_ERROR("config_walk");
+    return -CMD_ERR;
+  }
+
+  return 0;
+}
+
 int config_cmd_delete(int argc, char **argv, void *ctx)
 {
   struct config *config = ctx;
@@ -357,7 +376,9 @@ int config_cmd_clear(int argc, char **argv, void *ctx)
 const struct cmd config_commands[] = {
   { "save",              config_cmd_save,   .usage = "[FILE]",                          .describe = "Save config to filesystem"  },
   { "load",              config_cmd_load,   .usage = "[FILE]",                          .describe = "Load config from filesystem"  },
+  { "list",              config_cmd_list,   .usage = "",                                .describe = "List configs from filesystem"  },
   { "delete",            config_cmd_delete, .usage = "[FILE]",                          .describe = "Delete config from filesystem" },
+
   { "show",              config_cmd_show,   .usage = "[SECTION]",                       .describe = "Show config settings"  },
   { "get",               config_cmd_get,    .usage = "SECTION NAME",                    .describe = "Get config setting"    },
   { "set",               config_cmd_set,    .usage = "SECTION NAME VALUE [VALUE ...]",  .describe = "Set and write config"  },

--- a/components/config/cmd.c
+++ b/components/config/cmd.c
@@ -375,6 +375,63 @@ int config_cmd_clear(int argc, char **argv, void *ctx)
   return 0;
 }
 
+int config_cmd_reset(int argc, char **argv, void *ctx)
+{
+  struct config *config = ctx;
+  const char *section = NULL, *name = NULL;
+  const struct configmod *module = NULL;
+  const struct configtab *table = NULL;
+  int err;
+
+  if (argc >= 2 && (err = cmd_arg_str(argc, argv, 1, &section))) {
+    return err;
+  }
+  if (argc >= 3 && (err = cmd_arg_str(argc, argv, 2, &name))) {
+    return err;
+  }
+
+  if (section) {
+    if (configmod_lookup(config->modules, section, &module, &table)) {
+      LOG_ERROR("Unkonwn config section: %s", section);
+      return -CMD_ERR_ARGV;
+    }
+  }
+
+  if (section && name) {
+    const struct configtab *tab = NULL;
+
+    if (configtab_lookup(table, name, &tab)) {
+      LOG_ERROR("Unkonwn config name: %s.%s", section, name);
+      return -CMD_ERR_ARGV;
+    }
+
+    LOG_INFO("reset [%s] %s...", section, name);
+
+    if (configtab_reset(tab)) {
+      LOG_ERROR("configtab_reset");
+      return -1;
+    }
+  } else if (section) {
+    LOG_INFO("reset [%s]...", section);
+
+    if (configmod_reset(module, table)) {
+      LOG_ERROR("configmod_reset");
+      return -1;
+    }
+  } else {
+    LOG_INFO("reset...");
+
+    if (config_reset(config)) {
+      LOG_ERROR("config_reset");
+      return -1;
+    }
+  }
+
+  LOG_WARN("config modified, use `config save` and reboot");
+
+  return 0;
+}
+
 const struct cmd config_commands[] = {
   { "save",              config_cmd_save,   .usage = "[FILE]",                          .describe = "Save config to filesystem"  },
   { "load",              config_cmd_load,   .usage = "[FILE]",                          .describe = "Load config from filesystem"  },
@@ -383,7 +440,8 @@ const struct cmd config_commands[] = {
 
   { "show",              config_cmd_show,   .usage = "[SECTION]",                       .describe = "Show config settings"  },
   { "get",               config_cmd_get,    .usage = "SECTION NAME",                    .describe = "Get config setting"    },
-  { "set",               config_cmd_set,    .usage = "SECTION NAME VALUE [VALUE ...]",  .describe = "Set and write config"  },
-  { "clear",             config_cmd_clear,  .usage = "SECTION NAME",                    .describe = "Clear and write config"  },
+  { "set",               config_cmd_set,    .usage = "SECTION NAME VALUE [VALUE ...]",  .describe = "Set config value"  },
+  { "clear",             config_cmd_clear,  .usage = "SECTION NAME",                    .describe = "Clear config value"  },
+  { "reset",             config_cmd_reset,  .usage = "[SECTION] [NAME]",                .describe = "Reset config values to default"  },
   {}
 };

--- a/components/config/config.c
+++ b/components/config/config.c
@@ -155,7 +155,7 @@ int config_lookup(const struct config *config, const char *module, const char *n
     return 0;
 }
 
-int configtab_init(const struct configtab *tab)
+int configtab_reset(const struct configtab *tab)
 {
   if (tab->count) {
     *tab->count = 0;
@@ -189,14 +189,13 @@ int configtab_init(const struct configtab *tab)
   return 0;
 }
 
-
-int configmod_init(const struct configmod *module, const struct configtab *table)
+int configmod_reset(const struct configmod *module, const struct configtab *table)
 {
   int err;
 
   for (const struct configtab *tab = table; tab->name; tab++) {
-    if ((err = configtab_init(tab))) {
-      LOG_ERROR("configtab_init %s.%s", module->name, tab->name);
+    if ((err = configtab_reset(tab))) {
+      LOG_ERROR("configtab_reset %s.%s", module->name, tab->name);
       return err;
     }
   }
@@ -204,21 +203,21 @@ int configmod_init(const struct configmod *module, const struct configtab *table
   return 0;
 }
 
-int config_init(struct config *config)
+int config_reset(struct config *config)
 {
   int err;
 
   for (const struct configmod *mod = config->modules; mod->name; mod++) {
     if (mod->tables_count) {
       for (int i = 0; i < mod->tables_count; i++) {
-        if ((err = configmod_init(mod, mod->tables[i]))) {
-          LOG_ERROR("configmod_init: %s%d", mod->name, i + 1);
+        if ((err = configmod_reset(mod, mod->tables[i]))) {
+          LOG_ERROR("configmod_reset: %s%d", mod->name, i + 1);
           return err;
         }
       }
     } else {
-      if ((err = configmod_init(mod, mod->table))) {
-        LOG_ERROR("configmod_init: %s", mod->name);
+      if ((err = configmod_reset(mod, mod->table))) {
+        LOG_ERROR("configmod_reset: %s", mod->name);
         return err;
       }
     }
@@ -458,4 +457,9 @@ int config_print(const struct configmod *mod, const struct configtab *tab, unsig
   }
 
   return 0;
+}
+
+int config_init(struct config *config)
+{
+  return config_reset(config);
 }

--- a/components/config/file.c
+++ b/components/config/file.c
@@ -4,6 +4,31 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/dirent.h>
+
+int config_walk(struct config *config, int (func)(const char *filename, void *ctx), void *ctx)
+{
+  DIR *dir;
+  struct dirent *d;
+  int err = 0;
+
+  if (!(dir = opendir(config->path))) {
+    LOG_ERROR("opendir %s: %s", config->path, strerror(errno));
+    return -1;
+  }
+
+  while ((d = readdir(dir))) {
+    const char *filename = d->d_name;
+
+    if ((err = func(filename, ctx))) {
+      break;
+    }
+  }
+
+  closedir(dir);
+
+  return err;
+}
 
 int config_load(struct config *config, const char *filename)
 {

--- a/components/config/file.c
+++ b/components/config/file.c
@@ -17,11 +17,15 @@ int config_load(struct config *config)
 
   LOG_INFO("%s", config->filename);
 
-  if ((err = config_read(config, file))) {
-    fclose(file);
-    return err;
+  if ((err = config_init(config))) {
+    goto error;
   }
 
+  if ((err = config_read(config, file))) {
+    goto error;
+  }
+
+error:
   fclose(file);
 
   return err;

--- a/components/config/file.c
+++ b/components/config/file.c
@@ -6,6 +6,36 @@
 #include <string.h>
 #include <sys/dirent.h>
 
+static bool match_fileext(const char *filename, const char *ext)
+{
+  const char *suffix = strrchr(filename, '.');
+
+  if (!suffix) {
+    return false;
+  }
+
+  if (strcmp(suffix + 1, ext)) {
+    return false;
+  }
+
+  return true;
+}
+
+static int config_path(struct config *config, const char *filename, const char *ext, char *buf, size_t size)
+{
+  if (!match_fileext(filename, ext)) {
+    LOG_ERROR("filename must end with .%s: %s", ext, filename);
+    return -1;
+  }
+
+  if (snprintf(buf, size, "%s/%s", config->path, filename) >= size) {
+    LOG_ERROR("filename too long: %s", filename);
+    return -1;
+  }
+
+  return 0;
+}
+
 int config_walk(struct config *config, int (func)(const char *filename, void *ctx), void *ctx)
 {
   DIR *dir;
@@ -19,6 +49,10 @@ int config_walk(struct config *config, int (func)(const char *filename, void *ct
 
   while ((d = readdir(dir))) {
     const char *filename = d->d_name;
+
+    if (!match_fileext(filename, CONFIG_FILE_EXT)) {
+      continue;
+    }
 
     if ((err = func(filename, ctx))) {
       break;
@@ -36,9 +70,8 @@ int config_load(struct config *config, const char *filename)
   FILE *file;
   int err = 0;
 
-  if (snprintf(path, sizeof(path), "%s/%s", config->path, filename) >= sizeof(path)) {
-    LOG_ERROR("filename too long: %s", filename);
-    return -1;
+  if ((err = config_path(config, filename, CONFIG_FILE_EXT, path, sizeof(path)))) {
+    return err;
   }
 
   if ((file = fopen(path, "r")) == NULL) {
@@ -64,17 +97,16 @@ error:
 
 int config_save(struct config *config, const char *filename)
 {
-  char newfile[CONFIG_PATH_SIZE];
   char path[CONFIG_PATH_SIZE];
+  char newfile[CONFIG_PATH_SIZE];
   FILE *file;
   int err = 0;
 
-  if (snprintf(path, sizeof(path), "%s/%s", config->path, filename) >= sizeof(path)) {
-    LOG_ERROR("filename too long: %s", filename);
-    return -1;
+  if ((err = config_path(config, filename, CONFIG_FILE_EXT, path, sizeof(path)))) {
+    return err;
   }
 
-  if (snprintf(newfile, sizeof(newfile), "%s/%s.new", config->path, filename) >= sizeof(newfile)) {
+  if (snprintf(newfile, sizeof(newfile), "%s.new", path) >= sizeof(newfile)) {
     LOG_ERROR("filename too long: %s.new", filename);
     return -1;
   }
@@ -116,10 +148,10 @@ int config_save(struct config *config, const char *filename)
 int config_delete(struct config *config, const char *filename)
 {
   char path[CONFIG_PATH_SIZE];
+  int err;
 
-  if (snprintf(path, sizeof(path), "%s/%s", config->path, filename) >= sizeof(path)) {
-    LOG_ERROR("filename too long: %s", filename);
-    return -1;
+  if ((err = config_path(config, filename, CONFIG_FILE_EXT, path, sizeof(path)))) {
+    return err;
   }
 
   if (remove(path) == 0) {

--- a/components/config/include/config.h
+++ b/components/config/include/config.h
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 
+#define CONFIG_FILE_EXT "ini"
 #define CONFIG_BOOT_FILE "boot.ini"
 
 #define CONFIG_PATH_SIZE 64

--- a/components/config/include/config.h
+++ b/components/config/include/config.h
@@ -5,7 +5,9 @@
 #include <stdio.h>
 #include <stdbool.h>
 
-#define CONFIG_FILENAME 64
+#define CONFIG_BOOT_FILE "boot.ini"
+
+#define CONFIG_PATH_SIZE 64
 #define CONFIG_LINE 512
 #define CONFIG_NAME_SIZE 64
 #define CONFIG_VALUE_SIZE 256
@@ -83,7 +85,7 @@ struct configmod {
 };
 
 struct config {
-  const char *filename;
+  const char *path;
 
   const struct configmod *modules;
 };
@@ -130,13 +132,31 @@ int config_get(const struct configmod *mod, const struct configtab *tab, unsigne
 /* Print value at index (typically 0, if not multi-valued) to file */
 int config_print(const struct configmod *mod, const struct configtab *tab, unsigned index, FILE *file);
 
+/*
+ * Set config from file contents.
+ *
+ * The config must be empty (`config_init()`), or values will be duplicated!
+ */
 int config_read(struct config *config, FILE *file);
-int config_write(struct config *config, FILE *file);
-
-int config_load(struct config *config);
-int config_save(struct config *config);
 
 /*
- * Returns <0 on error, 0 if reset, >0 if nothing to reset.
+ * Write config to file.
  */
-int config_reset(struct config *config);
+int config_write(struct config *config, FILE *file);
+
+/*
+ * Load config from file.
+ */
+int config_load(struct config *config, const char *filename);
+
+/*
+ * Save config to file.
+ */
+int config_save(struct config *config, const char *filename);
+
+/*
+ * Remove config file.
+ *
+ * Returns <0 on error, 0 if reset, >0 if no file to remove.
+ */
+int config_delete(struct config *config, const char *filename);

--- a/components/config/include/config.h
+++ b/components/config/include/config.h
@@ -145,6 +145,11 @@ int config_read(struct config *config, FILE *file);
 int config_write(struct config *config, FILE *file);
 
 /*
+ * List available config files.
+ */
+int config_walk(struct config *config, int (func)(const char *filename, void *ctx), void *ctx);
+
+/*
  * Load config from file.
  */
 int config_load(struct config *config, const char *filename);

--- a/components/config/include/config.h
+++ b/components/config/include/config.h
@@ -114,12 +114,10 @@ static inline int configtab_count(const struct configtab *tab)
   }
 }
 
-/*
- * Set default values.
- *
- * Multi-valued configtabs are cleared.
- */
-int config_init(struct config *config);
+/* Reset value to defaults */
+int configtab_reset(const struct configtab *tab);
+int configmod_reset(const struct configmod *module, const struct configtab *table);
+int config_reset(struct config *config);
 
 /* Set empty value, or reset count to 0 if multi-valued */
 int config_clear(const struct configmod *mod, const struct configtab *tab);
@@ -134,9 +132,16 @@ int config_get(const struct configmod *mod, const struct configtab *tab, unsigne
 int config_print(const struct configmod *mod, const struct configtab *tab, unsigned index, FILE *file);
 
 /*
+ * Initialize to empty / default values.
+ *
+ * Multi-valued configtabs are cleared.
+ */
+int config_init(struct config *config);
+
+/*
  * Set config from file contents.
  *
- * The config must be empty (`config_init()`), or values will be duplicated!
+ * The config must be empty (`config_reset()`), or values will be duplicated!
  */
 int config_read(struct config *config, FILE *file);
 

--- a/components/config/read.c
+++ b/components/config/read.c
@@ -147,7 +147,7 @@ int config_read(struct config *config, FILE *file)
     LOG_DEBUG("%s", buf);
 
     if (config_parse(buf, &section, &name, &value)) {
-      LOG_WARN("Invalid line at %s:%d", config->filename, lineno);
+      LOG_WARN("Invalid line %d", lineno);
       continue;
     }
 

--- a/main/config.c
+++ b/main/config.c
@@ -20,7 +20,6 @@
 #include <sdkconfig.h>
 
 #define CONFIG_BASE_PATH "/config"
-#define CONFIG_FILE_NAME "boot.ini"
 #define CONFIG_PARTITON_LABEL "config"
 #define CONFIG_MAX_FILES 4
 
@@ -111,7 +110,7 @@ const struct configmod config_modules[] = {
 
 static bool config_disabled = false;
 struct config config = {
-  .filename = (CONFIG_BASE_PATH "/" CONFIG_FILE_NAME),
+  .path     = CONFIG_BASE_PATH,
 
   .modules = config_modules,
 };
@@ -152,17 +151,17 @@ int init_config()
     return 1;
   }
 
-  if (config_load(&config)) {
+  if (config_load(&config, CONFIG_BOOT_FILE)) {
     if (errno == ENOENT) {
-      LOG_WARN("spiffs file at %s not found", config.filename);
+      LOG_WARN("spiffs %s file at %s not found", CONFIG_BASE_PATH, CONFIG_BOOT_FILE);
       return 1;
     } else {
-      LOG_ERROR("config_load(%s)", config.filename);
+      LOG_ERROR("config_load(%s)", CONFIG_BOOT_FILE);
       return -1;
     }
   }
 
-  LOG_INFO("loaded config");
+  LOG_INFO("loaded boot config");
 
   return 0;
 }
@@ -172,13 +171,13 @@ void reset_config()
   int err;
 
   // attempt to remove the config boot.ini file
-  if ((err = config_reset(&config)) < 0) {
-    LOG_ERROR("config_reset");
+  if ((err = config_delete(&config, CONFIG_BOOT_FILE)) < 0) {
+    LOG_ERROR("config_delete");
   } else if (err > 0) {
-    LOG_INFO("no config file: %s", config.filename);
+    LOG_INFO("no config file: %s", CONFIG_BOOT_FILE);
     return;
   } else {
-    LOG_WARN("removed config file: %s", config.filename);
+    LOG_WARN("removed config file: %s", CONFIG_BOOT_FILE);
     return; // success
   }
 

--- a/main/config_http.c
+++ b/main/config_http.c
@@ -73,6 +73,12 @@ int config_post_handler_ini(struct http_request *request, struct http_response *
   LOG_INFO("config read...");
   LOG_DEBUG("file=%p", file);
 
+  if ((err = config_init(&config))) {
+    LOG_ERROR("config_init");
+    err = HTTP_INTERNAL_SERVER_ERROR;
+    goto error;
+  }
+
   if ((err = config_read(&config, file))) {
     LOG_WARN("config_read");
     err = HTTP_UNPROCESSABLE_ENTITY;

--- a/main/config_http.c
+++ b/main/config_http.c
@@ -85,9 +85,9 @@ int config_post_handler_ini(struct http_request *request, struct http_response *
     goto error;
   }
 
-  LOG_INFO("config save...");
+  LOG_INFO("config save %s", CONFIG_BOOT_FILE);
 
-  if ((err = config_save(&config))) {
+  if ((err = config_save(&config, CONFIG_BOOT_FILE))) {
     LOG_ERROR("config_save");
     goto error;
   }
@@ -308,7 +308,7 @@ static int config_api_write_config(struct json_writer *w, void *ctx)
   const struct config *config = ctx;
 
   return JSON_WRITE_OBJECT(w,
-        JSON_WRITE_MEMBER_STRING(w, "filename", config->filename)
+        JSON_WRITE_MEMBER_STRING(w, "filename", CONFIG_BOOT_FILE)
     ||  JSON_WRITE_MEMBER_ARRAY(w, "modules", config_api_write_config_modules(w, config))
   );
 }
@@ -410,9 +410,9 @@ int config_api_post_form(struct http_request *request, struct http_response *res
       return err;
     }
 
-    LOG_INFO("config save...");
+    LOG_INFO("config save %s", CONFIG_BOOT_FILE);
 
-    if ((err = config_save(&config))) {
+    if ((err = config_save(&config, CONFIG_BOOT_FILE))) {
       LOG_ERROR("config_save");
       return err;
     }


### PR DESCRIPTION
Fix #47 by re-initializing config before load/read.

Support for multiple `*.ini` config files with `config save`, `config load`, `config list`, `config delete` commands.

Require `config save` after `config set`, `config clear` (WARN).

New `config reset`, `config reset SECTION`, `config reset SECTION NAME` commands to restore default values.