### PR TITLE
CLI: Basic line editing

### DIFF
--- a/components/cli/cli.c
+++ b/components/cli/cli.c
@@ -142,8 +142,6 @@ int cli_main(struct cli *cli)
 
   LOG_DEBUG("cli=%p", cli);
 
-  memset(cli->buf, '\0', cli->size);
-
   if (!cli->timeout) {
     // skip open() step
   } else if ((err = cli_open(cli, cli->timeout)) < 0) {
@@ -184,6 +182,8 @@ int cli_init(struct cli **clip, const struct cmd *commands, struct cli_options o
   if (!(cli->buf = malloc(options.buf_size))) {
     LOG_ERROR("malloc buf");
     goto error;
+  } else {
+    memset(cli->buf, '\0', options.buf_size);
   }
 
   if ((err = cmd_eval_new(&cli->cmd_eval, options.max_args))) {

--- a/components/cli/cli.c
+++ b/components/cli/cli.c
@@ -154,28 +154,41 @@ static int cli_read(struct cli *cli)
       return 1;
     }
 
-    // echo
-    fputc(c, stdout);
+    switch(c) {
+      case '\b':
+        if (ptr > cli->buf) {
+          // erase one char
+          ptr--;
 
-    // handle CR or LF
-    if (c == '\r') {
-      fputc('\n', stdout);
-    }
+          // echo wipeout
+          fprintf(stdout, "\b \b");
+        }
 
-    if (c == '\b' && ptr > cli->buf) {
-      // erase one char
-      ptr--;
+        break;
 
-      // echo wipeout
-      fprintf(stdout, " \b");
+      case '\r':
+        // echo CR -> CRLF
+        fputc('\r', stdout);
 
-    } else if (c == '\r' || c == '\n') {
-      *ptr = '\0';
+        /* fall-through */
 
-      return 0;
-    } else {
-      // copy
-      *ptr++ = c;
+      case '\n':
+        // echo
+        fputc('\n', stdout);
+
+        // end
+        *ptr = '\0';
+
+        return 0;
+
+      default:
+        // echo
+        fputc(c, stdout);
+
+        // copy
+        *ptr++ = c;
+
+        break;
     }
   }
 

--- a/components/cli/cli.c
+++ b/components/cli/cli.c
@@ -133,13 +133,6 @@ static int cli_eval(struct cli *cli)
     LOG_ERROR("cmd %s: %d", line, err);
   }
 
-  // undo NULs used by cmd_eval argv, allow history recall
-  for (char *p = cli->buf; p < cli->ptr && p < cli->buf + cli->size; p++) {
-    if (*p == '\0') {
-      *p = ' ';
-    }
-  }
-
   return err;
 }
 

--- a/components/cli/cli.c
+++ b/components/cli/cli.c
@@ -133,6 +133,13 @@ static int cli_eval(struct cli *cli)
     LOG_ERROR("cmd %s: %d", line, err);
   }
 
+  // undo NULs used by cmd_eval argv, allow history recall
+  for (char *p = cli->buf; p < cli->ptr && p < cli->buf + cli->size; p++) {
+    if (*p == '\0') {
+      *p = ' ';
+    }
+  }
+
   return err;
 }
 

--- a/components/cli/cli.h
+++ b/components/cli/cli.h
@@ -4,7 +4,8 @@
 #include <cmd.h>
 
 struct cli {
-  char *buf, *ptr;
+  char *buf, *ptr, *end;
+  char *prev_end;
   size_t size;
   TickType_t timeout;
 

--- a/components/cli/cli.h
+++ b/components/cli/cli.h
@@ -4,7 +4,7 @@
 #include <cmd.h>
 
 struct cli {
-  char *buf;
+  char *buf, *ptr;
   size_t size;
   TickType_t timeout;
 
@@ -14,3 +14,6 @@ struct cli {
   // false once cli_exit() called
   bool run;
 };
+
+// process one line of input
+int cli_readline(struct cli *cli);

--- a/components/cli/readline.c
+++ b/components/cli/readline.c
@@ -1,0 +1,155 @@
+#include "cli.h"
+
+#include <logging.h>
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#if CONFIG_NEWLIB_VFS_STDIO
+  #define HAVE_STDIO_FCNTL 1
+
+  #include <stdio_fcntl.h>
+#endif
+
+enum state {
+  ASCII,
+  ESC,
+  CSI,
+  END,
+};
+
+static enum state cli_readline_ascii(struct cli *cli, char c)
+{
+  switch(c) {
+    case '\b':
+      if (cli->ptr > cli->buf) {
+        // erase one char
+        cli->ptr--;
+
+        // echo wipeout
+        fprintf(stdout, "\b \b");
+      }
+
+      return ASCII;
+
+    case '\e':
+      return ESC;
+
+    case '\r':
+      // echo CR -> CRLF
+      fputc('\r', stdout);
+
+      /* fall-through */
+
+    case '\n':
+      // echo
+      fputc('\n', stdout);
+
+      // end
+      *cli->ptr = '\0';
+
+      return END;
+
+    default:
+      // echo
+      fputc(c, stdout);
+
+      // copy
+      *cli->ptr++ = c;
+
+      return ASCII;
+  }
+}
+
+static enum state cli_readline_esc(struct cli *cli, char c)
+{
+  switch(c) {
+    case '[':
+      return CSI;
+
+    default:
+      return ASCII;
+  }
+}
+
+static enum state cli_readline_csi(struct cli *cli, char c)
+{
+  switch(c) {
+    case 0x20 ... 0x2F:  // intermediate
+      return CSI;
+
+    case 0x30 ... 0x3F:  // parameter
+      return CSI;
+
+    default:
+      return ASCII;
+  }
+}
+
+int cli_readline(struct cli *cli)
+{
+  enum state state = ASCII;
+  int c;
+
+  // reset EOF state
+  clearerr(stdin);
+
+#if HAVE_STDIO_FCNTL
+  // disable stdin timeout
+  if (fcntl(STDIN_FILENO, F_SET_READ_TIMEOUT, 0) < 0) {
+    LOG_WARN("fcntl stdin: %s", strerror(errno));
+  }
+#endif
+
+  // start
+  cli->ptr = cli->buf;
+
+  printf("> ");
+
+  while ((c = fgetc(stdin)) != EOF) {
+    #ifdef DEBUG
+      if (isprint(c)) {
+        LOG_DEBUG("%c", c);
+      } else {
+        LOG_DEBUG("%#02x", c);
+      }
+    #endif
+
+    if (cli->ptr >= cli->buf + cli->size) {
+      LOG_WARN("line overflow");
+      return 1;
+    }
+
+    switch(state) {
+      case ASCII:
+        state = cli_readline_ascii(cli, c);
+        break;
+
+      case ESC:
+        state = cli_readline_esc(cli, c);
+        break;
+
+      case CSI:
+        state = cli_readline_csi(cli, c);
+        break;
+
+      default:
+        LOG_FATAL("state=%d", state);
+    }
+
+    if (state == END) {
+      return 0;
+    }
+  }
+
+  if (ferror(stdin)) {
+    LOG_ERROR("stdin: %s", strerror(errno));
+    return -1;
+  }
+
+  // EOF
+  LOG_WARN("EOF");
+  return -1;
+}

--- a/components/cli/readline.c
+++ b/components/cli/readline.c
@@ -40,8 +40,8 @@ static enum state cli_readline_ascii_insert(struct cli *cli, char c)
   }
 
   // restore cursor position
-  for (char *p = cli->end; p > cli->ptr; p--) {
-    fputc('\b', stdout);
+  if (cli->ptr < cli->end) {
+    fprintf(stdout, "\e[%dD", (cli->end - cli->ptr));
   }
 
   return ASCII;
@@ -68,11 +68,7 @@ static enum state cli_readline_ascii_remove(struct cli *cli, char c)
     fputc(' ', stdout);
 
     // restore cursor position
-    for (char *p = cli->end; p > cli->ptr; p--) {
-      fputc('\b', stdout);
-    }
-
-    fputc('\b', stdout);
+    fprintf(stdout, "\e[%dD", (cli->end - cli->ptr + 1));
   }
 
   return ASCII;

--- a/components/cli/readline.c
+++ b/components/cli/readline.c
@@ -74,6 +74,24 @@ static enum state cli_readline_esc(struct cli *cli, char c)
   }
 }
 
+enum readline_csi_command {
+  CSI_CURSOR_UP = 'A',
+};
+
+static enum state cli_readline_csi_cursor_up(struct cli *cli)
+{
+  if (cli->ptr == cli->buf) {
+    // restore previous line
+    while (*cli->ptr) {
+      char c = *cli->ptr++;
+
+      fputc(c, stdout);
+    }
+  }
+
+  return ASCII;
+}
+
 static enum state cli_readline_csi(struct cli *cli, char c)
 {
   switch(c) {
@@ -82,6 +100,9 @@ static enum state cli_readline_csi(struct cli *cli, char c)
 
     case 0x30 ... 0x3F:  // parameter
       return CSI;
+
+    case CSI_CURSOR_UP:
+      return cli_readline_csi_cursor_up(cli);
 
     default:
       return ASCII;

--- a/components/cli/readline.c
+++ b/components/cli/readline.c
@@ -208,6 +208,7 @@ int cli_readline(struct cli *cli)
   }
 #endif
 
+  // history recall
   if (cli->end) {
     // undo NULs used by cmd_eval argv for history recall
     for (char *p = cli->buf; p < cli->end; p++) {
@@ -215,10 +216,11 @@ int cli_readline(struct cli *cli)
         *p = ' ';
       }
     }
+
+    cli->prev_end = cli->end;
   }
 
   // start
-  cli->prev_end = cli->end;
   cli->ptr = cli->end = cli->buf;
 
   printf("%s", CLI_READLINE_PROMPT);

--- a/components/cli/readline.c
+++ b/components/cli/readline.c
@@ -4,8 +4,10 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #if CONFIG_NEWLIB_VFS_STDIO
   #define HAVE_STDIO_FCNTL 1


### PR DESCRIPTION
Fix backspace echo at start of line.

Add basic line editing support for the [CSI](https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences) cursor movement commands:
* `\e[A` up-arrow at start of line restores previous line
* `\e[B` down-arrow clears line
* `\e[C` right-arrow moves cursor right, unless at end of line
* `\e[D` left-arrow moves cursor left, unless at start of line
* `\e[...` any other commands are ignored

The previous character insert/delete line editing commands are updated to handle cursor movements:
* backspace removes character before cursor and shifts remaining line, unless at start of line
* any other ASCII data inserts character at cursor and shifts remaining line