### PR TITLE
Fix /sdcard unmounted case

### DIFF
--- a/components/config/file.c
+++ b/components/config/file.c
@@ -73,8 +73,13 @@ int config_file_walk(const struct config_file_path *paths, int (*func)(const str
 
   for (const struct config_file_path *p = paths; p->prefix; p++) {
     if (!(dir = opendir(p->prefix))) {
-      LOG_ERROR("opendir %s: %s", p->prefix, strerror(errno));
-      return -1;
+      if (errno == ENOENT) {
+        LOG_DEBUG("opendir %s: %s", p->prefix, strerror(errno));
+        continue;
+      } else {
+        LOG_ERROR("opendir %s: %s", p->prefix, strerror(errno));
+        return -1;
+      }
     }
 
     while ((d = readdir(dir))) {

--- a/main/vfs_http.c
+++ b/main/vfs_http.c
@@ -544,13 +544,13 @@ static int vfs_http_api_write_directory(struct json_writer *w, void *ctx)
 static int vfs_http_api_write_mount_object(struct json_writer *w, const struct vfs_mount *mount, DIR *dir)
 {
   struct vfs_stat stat = {};
-  int err = 0;
+  int err = 0, ret;
 
   err |= JSON_WRITE_MEMBER_STRING(w, "path", mount->path);
 
-  if ((err = vfs_mount_stat(mount, &stat)) < 0) {
+  if ((ret = vfs_mount_stat(mount, &stat)) < 0) {
     LOG_WARN("mount path=%s dev stat", mount->path);
-  } else if (err) {
+  } else if (ret) {
     LOG_DEBUG("mount path=%s dev stat not supported", mount->path);
   } else {
     err |= JSON_WRITE_MEMBER_BOOL(w, "mounted", stat.mounted);


### PR DESCRIPTION
The VFS and Config web UI was broken if `/sdcard` was not mounted.