### PR TITLE
Implement Art-Net IP autoconf

### DIFF
--- a/components/system/esp32/netif.c
+++ b/components/system/esp32/netif.c
@@ -28,7 +28,7 @@ static esp_ip4_addr_t ipv4_network(const esp_netif_ip_info_t *ip_info)
 
 static unsigned ipv4_prefixlen(const esp_netif_ip_info_t *ip_info)
 {
-  uint32_t addr = esp_netif_htonl(ip_info->ip.addr);
+  uint32_t addr = esp_netif_htonl(ip_info->netmask.addr);
   unsigned len = 0;
 
   for (uint32_t mask = 1 << 31; mask; mask >>= 1) {

--- a/components/system/include/system_interfaces.h
+++ b/components/system/include/system_interfaces.h
@@ -34,8 +34,13 @@
 # define SYSTEM_IPV4_ADDR_BYTE4(x) esp_ip4_addr4(x)
 # define SYSTEM_IP_ADDR_TYPE esp_ip_addr_t
 
-  const char *esp_netif_dhcp_status_str(esp_netif_dhcp_status_t status);
+# if CONFIG_IEEE802154_ENABLED
+  typedef uint8_t system_mac_addr_t[8];
+# else
+  typedef uint8_t system_mac_addr_t[6];
+# endif
 
+  const char *esp_netif_dhcp_status_str(esp_netif_dhcp_status_t status);
 #endif
 
 struct system_interface_info {

--- a/main/Kconfig
+++ b/main/Kconfig
@@ -207,6 +207,9 @@ menu "qmsk-esp-eth"
       config ETH_MODE_DEFAULT_STATIC
         bool "Static IPv4"
 
+      config ETH_MODE_DEFAULT_AUTOCONF
+        bool "IPv4 autoconf"
+
       config ETH_MODE_DEFAULT_DHCP_CLIENT
         bool "DHCP Client"
 

--- a/main/Kconfig
+++ b/main/Kconfig
@@ -179,6 +179,11 @@ menu "qmsk-esp"
 
 endmenu
 
+menu "qmsk-artnet"
+  config ARTNET_ENABLED
+      bool "Enable artnet protocol by default"
+endmenu
+
 menu "qmsk-esp-eth"
   choice ETH_BOARD
     prompt "Ethernet board type"

--- a/main/artnet.c
+++ b/main/artnet.c
@@ -14,7 +14,7 @@
 
 #include <string.h>
 
-#define ARTNET_PRODUCT "https://github.com/SpComb/esp-projects"
+#define ARTNET_PRODUCT "https://github.com/qmsk/esp"
 
 #define ARTNET_INPUTS 4
 

--- a/main/artnet_config.c
+++ b/main/artnet_config.c
@@ -3,13 +3,22 @@
 #include "artnet_state.h"
 #include "artnet_config.h"
 
+#include <sdkconfig.h>
+
+
+#if CONFIG_ARTNET_ENABLED
+  #define ARTNET_CONFIG_ENABLED_DEFAULT true
+#else
+  #define ARTNET_CONFIG_ENABLED_DEFAULT false
+#endif
+
 struct artnet_config artnet_config = {
 
 };
 
 const struct configtab artnet_configtab[] = {
   { CONFIG_TYPE_BOOL, "enabled",
-    .bool_type = { .value = &artnet_config.enabled },
+    .bool_type = { .value = &artnet_config.enabled, .default_value = ARTNET_CONFIG_ENABLED_DEFAULT },
   },
   { CONFIG_TYPE_UINT16, "net",
     .description = "Set network address, 0-127.",

--- a/main/eth_config.h
+++ b/main/eth_config.h
@@ -11,6 +11,7 @@
 enum eth_mode {
   ETH_MODE_NONE,
   ETH_MODE_STATIC,
+  ETH_MODE_AUTOCONF,    // autoconf, generate host bits based on MAC addr
   ETH_MODE_DHCP_CLIENT,
   ETH_MODE_DHCP_SERVER,
 };

--- a/main/eth_netif.h
+++ b/main/eth_netif.h
@@ -5,6 +5,7 @@
 #if CONFIG_ETH_ENABLED
   int set_eth_netif_hostname(const char *hostname);
   int set_eth_netif_ip(const char *ip, const char *netmask, const char *gw);
+  int set_eth_netif_autoconf(const char *ip, const char *netmask, const char *gw);
 
   int set_eth_netif_static();
   int set_eth_netif_dhcpc();


### PR DESCRIPTION
Support `[eth]` config `mode = AUTOCONF` with `ip = 2.0.0.0` and `netmask = 255.0.0.0` to implement Art-NET addressing.

Add kconfigs to `[artnet]` `enabled = true` by default.

Example boardconfig / `sdkconfig.defaults`:

```
CONFIG_ETH_MODE_DEFAULT_AUTOCONF=y
CONFIG_ETH_IP_DEFAULT="2.0.0.0"
CONFIG_ETH_NETMASK_DEFAULT="255.0.0.0"
CONFIG_ETH_GW_DEFAULT="0.0.0.0"
CONFIG_ARTNET_ENABLED=y
```