### PR TITLE
leds update timeout

### DIFF
--- a/main/leds_artnet.c
+++ b/main/leds_artnet.c
@@ -84,7 +84,7 @@ static int leds_artnet_timeout(struct leds_state *state)
   struct leds_stats *stats = &leds_stats[state->index];
   int err;
 
-  LOG_INFO("leds%d: timeout", state->index + 1);
+  LOG_WARN("leds%d: timeout", state->index + 1);
 
   stats_counter_increment(&stats->artnet_timeout);
 

--- a/main/leds_cmd.c
+++ b/main/leds_cmd.c
@@ -360,6 +360,7 @@ int leds_cmd_stats(int argc, char **argv, void *ctx)
     print_stats_timer("task", "update",   &stats->update);
     printf("\n");
     print_stats_counter("artnet", "timeout", &stats->artnet_timeout);
+    print_stats_counter("update", "timeout", &stats->update_timeout);
     printf("\n");
   }
 

--- a/main/leds_config.h
+++ b/main/leds_config.h
@@ -146,6 +146,8 @@ struct leds_config {
   unsigned gpio_count;
 #endif
 
+  uint16_t update_timeout;
+
   bool test_enabled;
   int test_mode;
   bool test_auto;

--- a/main/leds_configtab.i
+++ b/main/leds_configtab.i
@@ -102,6 +102,11 @@ const struct configtab LEDS_CONFIGTAB[] = {
   },
 #endif
 
+  { CONFIG_TYPE_UINT16, "update_timeout",
+    .description = "Update LED outputs after given milliseconds without any updates. Default 0 -> hold output idle.",
+    .uint16_type = { .value = &LEDS_CONFIG.update_timeout },
+  },
+
   { CONFIG_TYPE_BOOL, "test_enabled",
     .description = "Enable test pattern output, active when TEST button pressed",
     .bool_type = { .value = &LEDS_CONFIG.test_enabled, .default_value = true },

--- a/main/leds_state.h
+++ b/main/leds_state.h
@@ -17,6 +17,7 @@ struct leds_state {
   const struct leds_config *config;
 
   struct leds *leds;
+  TickType_t update_tick;
 
   xTaskHandle task;
   EventGroupHandle_t event_group;

--- a/main/leds_stats.c
+++ b/main/leds_stats.c
@@ -23,5 +23,6 @@ void init_leds_stats()
     stats_timer_init(&stats->update);
 
     stats_counter_init(&stats->artnet_timeout);
+    stats_counter_init(&stats->update_timeout);
   }
 }

--- a/main/leds_stats.h
+++ b/main/leds_stats.h
@@ -20,6 +20,7 @@ struct leds_stats {
   struct stats_timer sequence;
 
   struct stats_timer update;
+  struct stats_counter update_timeout;
 };
 
 extern struct leds_sequence_stats leds_sequence_stats;

--- a/main/leds_task.c
+++ b/main/leds_task.c
@@ -37,6 +37,7 @@ static bool leds_update_active(struct leds_state *state)
 
 static EventBits_t leds_task_wait(struct leds_state *state)
 {
+  // XXX: how to handle tick overflow? with uint32_t TickType @ 100Hz, this will likely bug out after ~497 days of uptime...
   TickType_t tick;
 
   // first tick to wait until


### PR DESCRIPTION
Update outputs on timeout interval when idle.

Allows reconnecting LED outputs with a non-animated test pattern.

The update interval only becomes active after the first update, i.e. at boot the outputs will hold the outputs idle waiting for the first Art-NET update. Use this in combination with `artnet_dmx_timeout` to clear outputs at boot.