### PR TITLE
artnet: fix artnet_packet_poll_reply.sub_switch bits

### DIFF
--- a/components/artnet/protocol.c
+++ b/components/artnet/protocol.c
@@ -49,7 +49,7 @@ int artnet_send_poll_reply(struct artnet *artnet, struct artnet_sendrecv *send)
 
   reply->port_number = artnet_pack_u16lh(artnet->options.port);
   reply->net_switch = (artnet->options.address & 0x7F00) >> 8;
-  reply->sub_switch = (artnet->options.address & 0x00F0) >> 0;
+  reply->sub_switch = (artnet->options.address & 0x00F0) >> 4;
 
   strncpy((char *) reply->short_name, artnet->options.metadata.short_name, sizeof(reply->short_name));
   strncpy((char *) reply->long_name, artnet->options.metadata.long_name, sizeof(reply->long_name));


### PR DESCRIPTION
The [`ArtPollReply->SubSwitch`](https://art-net.org.uk/how-it-works/discovery-packets/artpollreply/) bits were incorrect:

> SubSwitch defines bits 7-4 of the 15-bit Port-Address of all the inputs and outputs supported by this node. The most significant 4 bits of SubSwitch are always zero.

This caused MagicQ to show a `[artnet] subnet = 2` node as having a starting universe of 256, i.e. Net 2.