### PR TITLE
esp32: upgrade esp-idf 4.4.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   NODE_VERSION: 15.x
-  ESP_IDF_VERSION: v4.4
+  ESP_IDF_VERSION: v4.4.6
   ESP8266_RTOS_SDK_VERSION: v3.4
 
 jobs:

--- a/components/system/include/system_wifi.h
+++ b/components/system/include/system_wifi.h
@@ -7,4 +7,7 @@ const char *wifi_mode_str(wifi_mode_t mode);
 const char *wifi_auth_mode_str(wifi_auth_mode_t auth_mode);
 const char *wifi_cipher_type_str(wifi_cipher_type_t cipher_type);
 const char *wifi_err_reason_str(wifi_err_reason_t reason);
-const char *wifi_phy_mode_str(wifi_phy_mode_t phymode);
+
+#if !CONFIG_IDF_TARGET_ESP8266
+  const char *wifi_phy_mode_str(wifi_phy_mode_t phymode);
+#endif

--- a/components/system/include/system_wifi.h
+++ b/components/system/include/system_wifi.h
@@ -7,3 +7,4 @@ const char *wifi_mode_str(wifi_mode_t mode);
 const char *wifi_auth_mode_str(wifi_auth_mode_t auth_mode);
 const char *wifi_cipher_type_str(wifi_cipher_type_t cipher_type);
 const char *wifi_err_reason_str(wifi_err_reason_t reason);
+const char *wifi_phy_mode_str(wifi_phy_mode_t phymode);

--- a/components/system/wifi.c
+++ b/components/system/wifi.c
@@ -102,15 +102,17 @@ const char *wifi_err_reason_str(wifi_err_reason_t reason) {
   }
 }
 
-const char *wifi_phy_mode_str(wifi_phy_mode_t phymode)
-{
-  switch (phymode) {
-    case WIFI_PHY_MODE_LR:    return "LR";
-    case WIFI_PHY_MODE_11B:   return "11B";
-    case WIFI_PHY_MODE_11G:   return "11G";
-    case WIFI_PHY_MODE_HT20:  return "HT20";
-    case WIFI_PHY_MODE_HT40:  return "HT40";
-    case WIFI_PHY_MODE_HE20:  return "HE20";
-    default:                  return "?";
+#if !CONFIG_IDF_TARGET_ESP8266
+  const char *wifi_phy_mode_str(wifi_phy_mode_t phymode)
+  {
+    switch (phymode) {
+      case WIFI_PHY_MODE_LR:    return "LR";
+      case WIFI_PHY_MODE_11B:   return "11B";
+      case WIFI_PHY_MODE_11G:   return "11G";
+      case WIFI_PHY_MODE_HT20:  return "HT20";
+      case WIFI_PHY_MODE_HT40:  return "HT40";
+      case WIFI_PHY_MODE_HE20:  return "HE20";
+      default:                  return "?";
+    }
   }
-}
+#endif

--- a/components/system/wifi.c
+++ b/components/system/wifi.c
@@ -31,7 +31,7 @@ const char *wifi_auth_mode_str(wifi_auth_mode_t auth_mode) {
     case WIFI_AUTH_WPA2_WPA3_PSK:   return "WPA2/3-PSK";
 #if CONFIG_IDF_TARGET_ESP32
     case WIFI_AUTH_WAPI_PSK:        return "WPAI-PSK";
-#endif    
+#endif
     default:                        return "?";
   }
 }
@@ -99,5 +99,18 @@ const char *wifi_err_reason_str(wifi_err_reason_t reason) {
 #endif
 
     default: return "?";
+  }
+}
+
+const char *wifi_phy_mode_str(wifi_phy_mode_t phymode)
+{
+  switch (phymode) {
+    case WIFI_PHY_MODE_LR:    return "LR";
+    case WIFI_PHY_MODE_11B:   return "11B";
+    case WIFI_PHY_MODE_11G:   return "11G";
+    case WIFI_PHY_MODE_HT20:  return "HT20";
+    case WIFI_PHY_MODE_HT40:  return "HT40";
+    case WIFI_PHY_MODE_HE20:  return "HE20";
+    default:                  return "?";
   }
 }

--- a/main/wifi_cmd.c
+++ b/main/wifi_cmd.c
@@ -29,6 +29,7 @@ static int print_wifi_info_sta()
   uint8_t mac[6];
   wifi_config_t config;
   wifi_ap_record_t ap;
+  wifi_phy_mode_t phymode = -1;
   esp_err_t err;
 
   if ((err = esp_wifi_get_mac(ESP_IF_WIFI_STA, mac))) {
@@ -90,6 +91,12 @@ static int print_wifi_info_sta()
       ap.phy_lr   ? "LR"  : "",
       ap.wps      ? "WPS" : ""
     );
+  }
+
+  if ((err = esp_wifi_sta_get_negotiated_phymode(&phymode))) {
+    LOG_WARN("esp_wifi_sta_get_negotiated_phymode: %s", esp_err_to_name(err));
+  } else {
+    printf("\t\t%-20s: %s\n", "PHY Mode", wifi_phy_mode_str(phymode));
   }
 
   return 0;

--- a/main/wifi_cmd.c
+++ b/main/wifi_cmd.c
@@ -29,7 +29,6 @@ static int print_wifi_info_sta()
   uint8_t mac[6];
   wifi_config_t config;
   wifi_ap_record_t ap;
-  wifi_phy_mode_t phymode = -1;
   esp_err_t err;
 
   if ((err = esp_wifi_get_mac(ESP_IF_WIFI_STA, mac))) {
@@ -93,11 +92,15 @@ static int print_wifi_info_sta()
     );
   }
 
+#if !CONFIG_IDF_TARGET_ESP8266
+  wifi_phy_mode_t phymode = -1;
+  
   if ((err = esp_wifi_sta_get_negotiated_phymode(&phymode))) {
     LOG_WARN("esp_wifi_sta_get_negotiated_phymode: %s", esp_err_to_name(err));
   } else {
     printf("\t\t%-20s: %s\n", "PHY Mode", wifi_phy_mode_str(phymode));
   }
+#endif
 
   return 0;
 }

--- a/main/wifi_events.c
+++ b/main/wifi_events.c
@@ -57,10 +57,24 @@ static void on_sta_stop()
 
 static void on_sta_connected(wifi_event_sta_connected_t *event)
 {
-  LOG_INFO("ssid=%.32s bssid=%02x:%02x:%02x:%02x:%02x:%02x channel=%u authmode=%s",
+  int rssi = 0;
+  wifi_phy_mode_t phymode = -1;
+  esp_err_t err;
+
+  if ((err = esp_wifi_sta_get_rssi(&rssi))) {
+
+  }
+
+  if ((err = esp_wifi_sta_get_negotiated_phymode(&phymode))) {
+
+  }
+
+  LOG_INFO("ssid=%.32s bssid=%02x:%02x:%02x:%02x:%02x:%02x channel=%u rssi=%d phymode=%s authmode=%s",
     event->ssid,
     event->bssid[0], event->bssid[1], event->bssid[2], event->bssid[3], event->bssid[4], event->bssid[5],
     event->channel,
+    rssi,
+    wifi_phy_mode_str(phymode),
     wifi_auth_mode_str(event->authmode)
   );
 

--- a/main/wifi_events.c
+++ b/main/wifi_events.c
@@ -57,6 +57,7 @@ static void on_sta_stop()
 
 static void on_sta_connected(wifi_event_sta_connected_t *event)
 {
+#if !CONFIG_IDF_TARGET_ESP8266
   int rssi = 0;
   wifi_phy_mode_t phymode = -1;
   esp_err_t err;
@@ -68,13 +69,19 @@ static void on_sta_connected(wifi_event_sta_connected_t *event)
   if ((err = esp_wifi_sta_get_negotiated_phymode(&phymode))) {
 
   }
+#endif
 
   LOG_INFO("ssid=%.32s bssid=%02x:%02x:%02x:%02x:%02x:%02x channel=%u rssi=%d phymode=%s authmode=%s",
     event->ssid,
     event->bssid[0], event->bssid[1], event->bssid[2], event->bssid[3], event->bssid[4], event->bssid[5],
     event->channel,
+#if CONFIG_IDF_TARGET_ESP8266
+    0,
+    "?",
+#else
     rssi,
     wifi_phy_mode_str(phymode),
+#endif
     wifi_auth_mode_str(event->authmode)
   );
 

--- a/projects/esp32/docker-compose.yml
+++ b/projects/esp32/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     build:
       context: ../../sdk/esp-idf
       args:
+        # also update .github/workflows/build.yml `ESP_IDF_VERSION`
         ESP_IDF_VERSION: v4.4.6
         BUILD_UID: ${BUILD_UID}
         BUILD_GID: ${BUILD_GID}

--- a/projects/esp32/docker-compose.yml
+++ b/projects/esp32/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     build:
       context: ../../sdk/esp-idf
       args:
-        ESP_IDF_VERSION: v4.4.4
+        ESP_IDF_VERSION: v4.4.6
         BUILD_UID: ${BUILD_UID}
         BUILD_GID: ${BUILD_GID}
     command: idf.py --version


### PR DESCRIPTION
# TODO
- [x] https://github.com/espressif/esp-idf/releases/tag/v4.4.5
  - [x] https://github.com/espressif/esp-idf/commit/8df9bbd5f47406202ece579891f90501db56716f `esp_wifi_sta_get_negotiated_phymode()`
  - [x] https://github.com/espressif/esp-idf/commit/d337d9dc0b9ccceb903d266bb4a764b6a7818134 `i2s_ll_tx_set_chan_mod()`
    - use custom `i2s_out_tx_set_chan_mod()` instead
  - [x] https://github.com/espressif/esp-idf/commit/969569dec0e9bffb97ad1f25af39c6aa12212571 `i2s_ll_tx_start()`
    - does not affect esp32
- [x] https://github.com/espressif/esp-idf/releases/tag/v4.4.6
  - [x] https://github.com/espressif/esp-idf/commit/b96c98accf1958d4ddc98a4f3331d1514696b653 `emac_esp32_transmit()` -> `insufficient TX buffer size`
  - [x] https://github.com/espressif/esp-idf/commit/c739cdf50d7698b98441f9b7a9d331494e6aaf33 `esp_wifi_sta_get_rssi()`