### PR TITLE
Add partitions for 8M flash

### DIFF
--- a/projects/esp32/partitions-8M.csv
+++ b/projects/esp32/partitions-8M.csv
@@ -1,0 +1,10 @@
+# ESP-IDF Partition Table (Single factory app, no OTA, 8MB flash)
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x6000,
+phy_init, data, phy,     0xf000,  0x1000,
+config,   data, spiffs,  0x10000, 0xF0000,
+
+factory,  app,  factory, 0x100000, 2M,
+
+# 1MB spiffs /web-dist
+web-dist, data, spiffs,  0x500000, 0x100000,


### PR DESCRIPTION
>1MB code size with usb-pd + sd-spi

```
Error: app partition is too small for binary qmsk-esp32.bin size 0x102380:
  - Part 'factory' 0/0 @ 0x10000 size 0x100000 (overflow 0x2380)
```