### PR TITLE
Art-NET RGBW+I LED groups

### DIFF
--- a/components/leds/color.c
+++ b/components/leds/color.c
@@ -49,3 +49,28 @@ unsigned leds_colors_active (const struct leds_color *pixels, unsigned count, en
 
   return active;
 }
+
+struct leds_color leds_color_intensity (struct leds_color color, enum leds_parameter_type parameter_type, uint8_t intensity)
+{
+  switch (parameter_type) {
+    case LEDS_PARAMETER_DIMMER:
+      color.dimmer = intensity;
+      break;
+
+    case LEDS_PARAMETER_NONE:
+      color.r = color.r * intensity / 255;
+      color.g = color.g * intensity / 255;
+      color.b = color.b * intensity / 255;
+      color.parameter = 0;
+      break;
+
+    case LEDS_PARAMETER_WHITE:
+      color.r = color.r * intensity / 255;
+      color.g = color.g * intensity / 255;
+      color.b = color.b * intensity / 255;
+      color.w = color.w * intensity / 255;
+      break;
+  }
+
+  return color;
+}

--- a/components/leds/format.c
+++ b/components/leds/format.c
@@ -2,9 +2,9 @@
 
 #include <logging.h>
 
-unsigned leds_format_count(enum leds_format format, size_t len, size_t group)
+unsigned leds_format_count(size_t len, enum leds_format format, unsigned group)
 {
-  if (group == 0) {
+  if (!group) {
     group = 1;
   }
 

--- a/components/leds/format.c
+++ b/components/leds/format.c
@@ -18,7 +18,7 @@ unsigned leds_format_count(enum leds_format format, size_t len, size_t group)
     case LEDS_FORMAT_RGBW:
       return len / 4;
 
-    case LEDS_FORMAT_RGBWI:
+    case LEDS_FORMAT_RGBWXI:
       return len / (4 + group) * group;
 
     default:
@@ -123,7 +123,7 @@ void leds_set_format_rgbw(struct leds *leds, const uint8_t *data, size_t len, st
   }
 }
 
-void leds_set_format_rgbwi(struct leds *leds, const uint8_t *data, size_t len, struct leds_format_params params)
+void leds_set_format_rgbwxi(struct leds *leds, const uint8_t *data, size_t len, struct leds_format_params params)
 {
   enum leds_parameter_type parameter_type = leds_parameter_type(leds);
 
@@ -197,8 +197,8 @@ int leds_set_format(struct leds *leds, enum leds_format format, const void *data
       leds_set_format_rgbw(leds, data, len, params);
       return 0;
 
-    case LEDS_FORMAT_RGBWI:
-      leds_set_format_rgbwi(leds, data, len, params);
+    case LEDS_FORMAT_RGBWXI:
+      leds_set_format_rgbwxi(leds, data, len, params);
       return 0;
 
     default:

--- a/components/leds/format.c
+++ b/components/leds/format.c
@@ -2,8 +2,12 @@
 
 #include <logging.h>
 
-unsigned leds_format_count(enum leds_format format, size_t len)
+unsigned leds_format_count(enum leds_format format, size_t len, size_t group)
 {
+  if (group == 0) {
+    group = 1;
+  }
+
   switch (format) {
     case LEDS_FORMAT_RGB:
     case LEDS_FORMAT_BGR:
@@ -13,6 +17,9 @@ unsigned leds_format_count(enum leds_format format, size_t len)
     case LEDS_FORMAT_RGBA:
     case LEDS_FORMAT_RGBW:
       return len / 4;
+
+    case LEDS_FORMAT_RGBWI:
+      return len / (4 + group) * group;
 
     default:
       LOG_FATAL("invalid format=%d", format);
@@ -116,6 +123,35 @@ void leds_set_format_rgbw(struct leds *leds, const uint8_t *data, size_t len, st
   }
 }
 
+void leds_set_format_rgbwi(struct leds *leds, const uint8_t *data, size_t len, struct leds_format_params params)
+{
+  enum leds_parameter_type parameter_type = leds_parameter_type(leds);
+
+  LOG_DEBUG("len=%u offset=%u count=%u segment=%u group=%u", len, params.offset, params.count, params.segment, params.group);
+
+  size_t off = 0;
+
+  for (unsigned g = 0; g * params.group < params.count && len >= off + 4 + params.group; g++) {
+    struct leds_color group_color;
+
+    group_color.r = data[off++];
+    group_color.g = data[off++];
+    group_color.b = data[off++];
+    group_color.w = data[off++];
+
+    LOG_DEBUG("\tg=%u off=%u rgbw=%02x%02x%02x%02x", g, off, group_color.r, group_color.g, group_color.b, group_color.w);
+
+    for (unsigned i = 0; i < params.group && g * params.group + i < params.count; i++) {
+      uint8_t intensity = data[off++];
+      struct leds_color pixel_color = leds_color_intensity(group_color, parameter_type, intensity);
+
+      for (unsigned j = 0; j < params.segment; j++) {
+        leds->pixels[params.offset + g * params.group + i * params.segment + j] = pixel_color;
+      }
+    }
+  }
+}
+
 int leds_set_format(struct leds *leds, enum leds_format format, const void *data, size_t len, struct leds_format_params params)
 {
   if (params.count == 0) {
@@ -124,6 +160,10 @@ int leds_set_format(struct leds *leds, enum leds_format format, const void *data
 
   if (params.segment == 0) {
     params.segment = 1;
+  }
+
+  if (params.group == 0) {
+    params.group = 1;
   }
 
   if (params.offset > leds->options.count) {
@@ -155,6 +195,10 @@ int leds_set_format(struct leds *leds, enum leds_format format, const void *data
 
     case LEDS_FORMAT_RGBW:
       leds_set_format_rgbw(leds, data, len, params);
+      return 0;
+
+    case LEDS_FORMAT_RGBWI:
+      leds_set_format_rgbwi(leds, data, len, params);
       return 0;
 
     default:

--- a/components/leds/format.c
+++ b/components/leds/format.c
@@ -12,11 +12,11 @@ unsigned leds_format_count(size_t len, enum leds_format format, unsigned group)
     case LEDS_FORMAT_RGB:
     case LEDS_FORMAT_BGR:
     case LEDS_FORMAT_GRB:
-      return len / 3;
+      return len / (3 * group) * group;
 
     case LEDS_FORMAT_RGBA:
     case LEDS_FORMAT_RGBW:
-      return len / 4;
+      return len / (4 * group) * group;
 
     case LEDS_FORMAT_RGBWXI:
       return len / (4 + group) * group;

--- a/components/leds/format.c
+++ b/components/leds/format.c
@@ -18,6 +18,9 @@ unsigned leds_format_count(size_t len, enum leds_format format, unsigned group)
     case LEDS_FORMAT_RGBW:
       return len / (4 * group) * group;
 
+    case LEDS_FORMAT_RGBXI:
+      return len / (3 + group) * group;
+
     case LEDS_FORMAT_RGBWXI:
       return len / (4 + group) * group;
 
@@ -123,6 +126,36 @@ void leds_set_format_rgbw(struct leds *leds, const uint8_t *data, size_t len, st
   }
 }
 
+void leds_set_format_rgbxi(struct leds *leds, const uint8_t *data, size_t len, struct leds_format_params params)
+{
+  enum leds_parameter_type parameter_type = leds_parameter_type(leds);
+  uint8_t parameter_default = leds_parameter_default(leds);
+
+  LOG_DEBUG("len=%u offset=%u count=%u segment=%u group=%u", len, params.offset, params.count, params.segment, params.group);
+
+  size_t off = 0;
+
+  for (unsigned g = 0; g * params.group < params.count && len >= off + 3 + params.group; g++) {
+    struct leds_color group_color = {};
+
+    group_color.r = data[off++];
+    group_color.g = data[off++];
+    group_color.b = data[off++];
+    group_color.parameter = parameter_default;
+
+    LOG_DEBUG("\tg=%u off=%u rgb=%02x%02x%02x", g, off, group_color.r, group_color.g, group_color.b);
+
+    for (unsigned i = 0; i < params.group && g * params.group + i < params.count; i++) {
+      uint8_t intensity = data[off++];
+      struct leds_color pixel_color = leds_color_intensity(group_color, parameter_type, intensity);
+
+      for (unsigned j = 0; j < params.segment; j++) {
+        leds->pixels[params.offset + (g * params.group + i) * params.segment + j] = pixel_color;
+      }
+    }
+  }
+}
+
 void leds_set_format_rgbwxi(struct leds *leds, const uint8_t *data, size_t len, struct leds_format_params params)
 {
   enum leds_parameter_type parameter_type = leds_parameter_type(leds);
@@ -132,7 +165,7 @@ void leds_set_format_rgbwxi(struct leds *leds, const uint8_t *data, size_t len, 
   size_t off = 0;
 
   for (unsigned g = 0; g * params.group < params.count && len >= off + 4 + params.group; g++) {
-    struct leds_color group_color;
+    struct leds_color group_color = {};
 
     group_color.r = data[off++];
     group_color.g = data[off++];
@@ -195,6 +228,10 @@ int leds_set_format(struct leds *leds, enum leds_format format, const void *data
 
     case LEDS_FORMAT_RGBW:
       leds_set_format_rgbw(leds, data, len, params);
+      return 0;
+
+    case LEDS_FORMAT_RGBXI:
+      leds_set_format_rgbxi(leds, data, len, params);
       return 0;
 
     case LEDS_FORMAT_RGBWXI:

--- a/components/leds/format.c
+++ b/components/leds/format.c
@@ -146,7 +146,7 @@ void leds_set_format_rgbwi(struct leds *leds, const uint8_t *data, size_t len, s
       struct leds_color pixel_color = leds_color_intensity(group_color, parameter_type, intensity);
 
       for (unsigned j = 0; j < params.segment; j++) {
-        leds->pixels[params.offset + g * params.group + i * params.segment + j] = pixel_color;
+        leds->pixels[params.offset + (g * params.group + i) * params.segment + j] = pixel_color;
       }
     }
   }

--- a/components/leds/format.c
+++ b/components/leds/format.c
@@ -115,3 +115,50 @@ void leds_set_format_rgbw(struct leds *leds, const uint8_t *data, size_t len, st
     }
   }
 }
+
+int leds_set_format(struct leds *leds, enum leds_format format, const void *data, size_t len, struct leds_format_params params)
+{
+  if (params.count == 0) {
+    params.count = leds->options.count;
+  }
+
+  if (params.segment == 0) {
+    params.segment = 1;
+  }
+
+  if (params.offset > leds->options.count) {
+    LOG_DEBUG("offset=%u is over options.count=%u", params.offset, leds->options.count);
+    params.count = 0;
+  } else if (params.offset + (params.count * params.segment) > leds->options.count) {
+    LOG_DEBUG("offset=%u + count=%u * segment=%u is over options.count=%u", params.offset, params.count, params.segment, leds->options.count);
+    params.count = (leds->options.count - params.offset) / params.segment;
+  }
+
+  leds->pixels_limit_dirty = true;
+
+  switch(format) {
+    case LEDS_FORMAT_RGB:
+      leds_set_format_rgb(leds, data, len, params);
+      return 0;
+
+    case LEDS_FORMAT_BGR:
+      leds_set_format_bgr(leds, data, len, params);
+      return 0;
+
+    case LEDS_FORMAT_GRB:
+      leds_set_format_grb(leds, data, len, params);
+      return 0;
+
+    case LEDS_FORMAT_RGBA:
+      leds_set_format_rgba(leds, data, len, params);
+      return 0;
+
+    case LEDS_FORMAT_RGBW:
+      leds_set_format_rgbw(leds, data, len, params);
+      return 0;
+
+    default:
+      LOG_ERROR("unknown format=%#x", format);
+      return -1;
+  }
+}

--- a/components/leds/include/leds.h
+++ b/components/leds/include/leds.h
@@ -101,8 +101,10 @@ enum leds_format {
 
 /*
  * Return count of pixels that fit into len bytes using the given format.
+ *
+ * This does not consider segments.
  */
-unsigned leds_format_count(enum leds_format format, size_t len, size_t group);
+unsigned leds_format_count(size_t len, enum leds_format format, unsigned group);
 
 struct leds_format_params {
   /* Limit number of LED (segments) to read */

--- a/components/leds/include/leds.h
+++ b/components/leds/include/leds.h
@@ -96,6 +96,8 @@ enum leds_format {
   LEDS_FORMAT_GRB,
   LEDS_FORMAT_RGBA,
   LEDS_FORMAT_RGBW,
+
+  LEDS_FORMAT_RGBXI, // grouped RGB + intensity
   LEDS_FORMAT_RGBWXI, // grouped RGBW + intensity
 };
 

--- a/components/leds/include/leds.h
+++ b/components/leds/include/leds.h
@@ -96,12 +96,13 @@ enum leds_format {
   LEDS_FORMAT_GRB,
   LEDS_FORMAT_RGBA,
   LEDS_FORMAT_RGBW,
+  LEDS_FORMAT_RGBWI, // grouped
 };
 
 /*
- * Return count of LEDs that fit into len bytes using the given format.
+ * Return count of pixels that fit into len bytes using the given format.
  */
-unsigned leds_format_count(enum leds_format format, size_t len);
+unsigned leds_format_count(enum leds_format format, size_t len, size_t group);
 
 struct leds_format_params {
   /* Limit number of LED (segments) to read */
@@ -112,6 +113,9 @@ struct leds_format_params {
 
   /* Set segments of multiple consecutive LEDs per channel */
   unsigned segment;
+
+  /* Set color for group of LEDs */
+  unsigned group;
 };
 
 /*
@@ -316,10 +320,12 @@ struct leds_color {
     uint8_t parameter;
     uint8_t dimmer; // 0-255
     uint8_t white; // 0-255
+    uint8_t w; // 0-255
   };
 };
 
 bool leds_color_active (struct leds_color color, enum leds_parameter_type parameter_type);
+struct leds_color leds_color_intensity (struct leds_color color, enum leds_parameter_type parameter_type, uint8_t intensity);
 
 enum leds_test_mode {
   TEST_MODE_NONE  = 0,

--- a/components/leds/include/leds.h
+++ b/components/leds/include/leds.h
@@ -96,7 +96,7 @@ enum leds_format {
   LEDS_FORMAT_GRB,
   LEDS_FORMAT_RGBA,
   LEDS_FORMAT_RGBW,
-  LEDS_FORMAT_RGBWI, // grouped
+  LEDS_FORMAT_RGBWXI, // grouped RGBW + intensity
 };
 
 /*

--- a/components/leds/leds.c
+++ b/components/leds/leds.c
@@ -142,53 +142,6 @@ int leds_set_all(struct leds *leds, struct leds_color color)
   return 0;
 }
 
-int leds_set_format(struct leds *leds, enum leds_format format, const void *data, size_t len, struct leds_format_params params)
-{
-  if (params.count == 0) {
-    params.count = leds->options.count;
-  }
-
-  if (params.segment == 0) {
-    params.segment = 1;
-  }
-
-  if (params.offset > leds->options.count) {
-    LOG_DEBUG("offset=%u is over options.count=%u", params.offset, leds->options.count);
-    params.count = 0;
-  } else if (params.offset + (params.count * params.segment) > leds->options.count) {
-    LOG_DEBUG("offset=%u + count=%u * segment=%u is over options.count=%u", params.offset, params.count, params.segment, leds->options.count);
-    params.count = (leds->options.count - params.offset) / params.segment;
-  }
-
-  leds->pixels_limit_dirty = true;
-
-  switch(format) {
-    case LEDS_FORMAT_RGB:
-      leds_set_format_rgb(leds, data, len, params);
-      return 0;
-
-    case LEDS_FORMAT_BGR:
-      leds_set_format_bgr(leds, data, len, params);
-      return 0;
-
-    case LEDS_FORMAT_GRB:
-      leds_set_format_grb(leds, data, len, params);
-      return 0;
-
-    case LEDS_FORMAT_RGBA:
-      leds_set_format_rgba(leds, data, len, params);
-      return 0;
-
-    case LEDS_FORMAT_RGBW:
-      leds_set_format_rgbw(leds, data, len, params);
-      return 0;
-
-    default:
-      LOG_ERROR("unknown format=%#x", format);
-      return -1;
-  }
-}
-
 unsigned leds_count_active(struct leds *leds)
 {
   return leds_colors_active(leds->pixels, leds->options.count, leds->protocol_type->parameter_type);

--- a/main/leds_artnet.c
+++ b/main/leds_artnet.c
@@ -239,7 +239,11 @@ int init_leds_artnet(struct leds_state *state, int index, const struct leds_conf
     return -1;
   }
 
-  state->artnet->universe_leds_count = config_leds_artnet_universe_leds_count(config);
+  if (!(state->artnet->universe_leds_count = config_leds_artnet_universe_leds_count(config))) {
+    LOG_ERROR("invalid universe_leds_count, artnet_leds_group is too large?");
+    return -1;
+  }
+
   state->artnet->universe_count = config_leds_artnet_universe_count(config);
 
   LOG_INFO("universe_count=%u universe_leds_count=%u",

--- a/main/leds_artnet.h
+++ b/main/leds_artnet.h
@@ -10,6 +10,7 @@
 
 struct leds_artnet_state {
   unsigned universe_count;
+  unsigned universe_leds_count;
 
   struct artnet_dmx dmx;
   struct artnet_output **outputs;

--- a/main/leds_config.c
+++ b/main/leds_config.c
@@ -93,12 +93,12 @@ const struct config_enum leds_gpio_mode_enum[] = {
 #endif
 
 const struct config_enum leds_format_enum[] = {
-  { "RGB",   LEDS_FORMAT_RGB  },
-  { "BGR",   LEDS_FORMAT_BGR  },
-  { "GRB",   LEDS_FORMAT_GRB  },
-  { "RGBA",  LEDS_FORMAT_RGBA },
-  { "RGBW",  LEDS_FORMAT_RGBW },
-  { "RGBWI", LEDS_FORMAT_RGBWI },
+  { "RGB",    LEDS_FORMAT_RGB  },
+  { "BGR",    LEDS_FORMAT_BGR  },
+  { "GRB",    LEDS_FORMAT_GRB  },
+  { "RGBA",   LEDS_FORMAT_RGBA },
+  { "RGBW",   LEDS_FORMAT_RGBW },
+  { "RGBWxI", LEDS_FORMAT_RGBWXI },
   {}
 };
 

--- a/main/leds_config.c
+++ b/main/leds_config.c
@@ -93,11 +93,12 @@ const struct config_enum leds_gpio_mode_enum[] = {
 #endif
 
 const struct config_enum leds_format_enum[] = {
-  { "RGB",  LEDS_FORMAT_RGB  },
-  { "BGR",  LEDS_FORMAT_BGR  },
-  { "GRB",  LEDS_FORMAT_GRB  },
-  { "RGBA", LEDS_FORMAT_RGBA },
-  { "RGBW", LEDS_FORMAT_RGBW },
+  { "RGB",   LEDS_FORMAT_RGB  },
+  { "BGR",   LEDS_FORMAT_BGR  },
+  { "GRB",   LEDS_FORMAT_GRB  },
+  { "RGBA",  LEDS_FORMAT_RGBA },
+  { "RGBW",  LEDS_FORMAT_RGBW },
+  { "RGBWI", LEDS_FORMAT_RGBWI },
   {}
 };
 

--- a/main/leds_config.c
+++ b/main/leds_config.c
@@ -93,12 +93,13 @@ const struct config_enum leds_gpio_mode_enum[] = {
 #endif
 
 const struct config_enum leds_format_enum[] = {
-  { "RGB",    LEDS_FORMAT_RGB  },
-  { "BGR",    LEDS_FORMAT_BGR  },
-  { "GRB",    LEDS_FORMAT_GRB  },
-  { "RGBA",   LEDS_FORMAT_RGBA },
-  { "RGBW",   LEDS_FORMAT_RGBW },
-  { "RGBWxI", LEDS_FORMAT_RGBWXI },
+  { "RGB",    LEDS_FORMAT_RGB     },
+  { "BGR",    LEDS_FORMAT_BGR     },
+  { "GRB",    LEDS_FORMAT_GRB     },
+  { "RGBA",   LEDS_FORMAT_RGBA    },
+  { "RGBW",   LEDS_FORMAT_RGBW    },
+  { "RGBxI",  LEDS_FORMAT_RGBXI   },
+  { "RGBWxI", LEDS_FORMAT_RGBWXI  },
   {}
 };
 

--- a/main/leds_config.h
+++ b/main/leds_config.h
@@ -161,6 +161,7 @@ struct leds_config {
   uint16_t artnet_dmx_timeout;
   int artnet_leds_format;
   uint16_t artnet_leds_segment;
+  uint16_t artnet_leds_group;
 
   bool sequence_enabled;
   int sequence_format;

--- a/main/leds_configtab.i
+++ b/main/leds_configtab.i
@@ -158,6 +158,10 @@ const struct configtab LEDS_CONFIGTAB[] = {
     .description = "Control multiple consecutive LEDs per Art-Net DMX channel. Default 0 -> set individual LEDs",
     .uint16_type = { .value = &LEDS_CONFIG.artnet_leds_segment },
   },
+  { CONFIG_TYPE_UINT16, "artnet_leds_group",
+    .description = "Group up consecutive LEDs into the same Art-NET DMX universe. Default 0 -> individual LEDs",
+    .uint16_type = { .value = &LEDS_CONFIG.artnet_leds_group },
+  },
 
   { CONFIG_TYPE_BOOL, "sequence_enabled",
     .description = "Output LED sequence frames, requires leds-sequence config",

--- a/main/leds_configtab.i
+++ b/main/leds_configtab.i
@@ -159,7 +159,7 @@ const struct configtab LEDS_CONFIGTAB[] = {
     .uint16_type = { .value = &LEDS_CONFIG.artnet_leds_segment },
   },
   { CONFIG_TYPE_UINT16, "artnet_leds_group",
-    .description = "Group up consecutive LEDs into the same Art-NET DMX universe. Default 0 -> individual LEDs",
+    .description = "Group multiple consecutive LEDs into the same Art-NET DMX universe, optionally with common format parameters. Default 0 -> individual LEDs",
     .uint16_type = { .value = &LEDS_CONFIG.artnet_leds_group },
   },
 


### PR DESCRIPTION
Add a new `RGBWI` format + `artnet_leds_group` that allows patching pixels using a RGBW+I format, with one per-group RGBW color followed by separate per-pixel intensity values. This reduces the number of Art-NET universes and GrandMA parameters required for controlling pixel LEDs, trading reduced color resolution for improved intensity resolution compared to just `artnet_leds_segments`.