### PR TITLE
artnet: fix artnet poll_reply initialization, add bind_ip

### DIFF
--- a/components/artnet/protocol.c
+++ b/components/artnet/protocol.c
@@ -41,11 +41,13 @@ int artnet_send_poll_reply(struct artnet *artnet, struct artnet_sendrecv *send)
   // prepare header fields
   send->len = sizeof(send->packet->poll_reply);
 
+  memset(reply, 0, sizeof(*reply));
   memcpy(reply->id, artnet_id, sizeof(reply->id));
   reply->opcode = ARTNET_OP_POLL_REPLY;
 
   // prepare constant fields
-  memcpy(reply->ip_address, artnet->options.metadata.ip_address, 4);
+  memcpy(reply->ip_address, artnet->options.metadata.ip_address, sizeof(reply->ip_address));
+  memcpy(&reply->bind_ip, artnet->options.metadata.ip_address, sizeof(reply->bind_ip));
 
   reply->port_number = artnet_pack_u16lh(artnet->options.port);
   reply->net_switch = (artnet->options.address & 0x7F00) >> 8;


### PR DESCRIPTION
Unset artnet poll reply fields were uninitialized.

The BindIp field was missing: https://art-net.org.uk/how-it-works/discovery-packets/artpollreply/
> The BindIp represents the IP address of the Root device in an Art-Net product that has multiple IP addresses. In Art-Net 4, the BindIp is always identical to the IP of the root device.