### PR TITLE
leds: Add support for setup/active mode GPIO outputs

### DIFF
--- a/components/config/enum.c
+++ b/components/config/enum.c
@@ -1,4 +1,5 @@
 #include <config.h>
+#include <logging.h>
 
 #include <string.h>
 
@@ -6,6 +7,12 @@ int config_enum_lookup(const struct config_enum *e, const char *name, const stru
 {
   for (; e->name; e++) {
     if (strcmp(e->name, name) == 0) {
+      *enump = e;
+      return 0;
+    }
+
+    if (e->alias && strcmp(e->alias, name) == 0) {
+      LOG_WARN("deprecated enum alias %s, renamed to %s", name, e->name);
       *enump = e;
       return 0;
     }
@@ -41,6 +48,12 @@ int config_enum_to_value(const struct config_enum *e, const char *name)
 {
   for (; e->name; e++) {
     if (strcmp(e->name, name) == 0) {
+      return e->value;
+    }
+
+    if (e->alias && strcmp(e->alias, name) == 0) {
+      LOG_WARN("deprecated enum alias %s, renamed to %s", name, e->name);
+
       return e->value;
     }
   }

--- a/components/config/include/config.h
+++ b/components/config/include/config.h
@@ -26,6 +26,9 @@ enum config_type {
 struct config_enum {
   const char *name;
 
+  /* Migrate from old name */
+  const char *alias;
+
   int value;
 };
 

--- a/components/i2s_out/i2s_out.h
+++ b/components/i2s_out/i2s_out.h
@@ -33,6 +33,7 @@ struct i2s_out {
   /* pin */
   SemaphoreHandle_t pin_mutex;
 #if CONFIG_IDF_TARGET_ESP32
+  bool bck_gpio_inv;
   gpio_num_t bck_gpios[I2S_OUT_PARALLEL_SIZE];
   gpio_num_t data_gpios[I2S_OUT_PARALLEL_SIZE];
   gpio_num_t inv_data_gpios[I2S_OUT_PARALLEL_SIZE];

--- a/components/leds/gpio.c
+++ b/components/leds/gpio.c
@@ -1,0 +1,40 @@
+#include "gpio.h"
+
+#if CONFIG_LEDS_GPIO_ENABLED
+    void leds_gpio_setup (const struct leds_interface_options_gpio *options)
+    {
+        if (!options->gpio_options) {
+            return;
+        }
+
+        switch (options->mode) {
+            case LEDS_GPIO_MODE_NONE:
+                break;
+            
+            case LEDS_GPIO_MODE_SETUP:
+            case LEDS_GPIO_MODE_ACTIVE:
+                gpio_out_set(options->gpio_options, options->pins);
+                break;
+        }
+    }
+
+    void leds_gpio_close (const struct leds_interface_options_gpio *options)
+    {
+        if (!options->gpio_options) {
+            return;
+        }
+
+        switch (options->mode) {
+            case LEDS_GPIO_MODE_NONE:
+                break;
+            
+            case LEDS_GPIO_MODE_SETUP:
+                break;
+
+            case LEDS_GPIO_MODE_ACTIVE:
+                gpio_out_clear(options->gpio_options);
+                break;
+        }
+
+    }
+#endif

--- a/components/leds/gpio.h
+++ b/components/leds/gpio.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <leds.h>
+
+#if CONFIG_LEDS_GPIO_ENABLED
+    void leds_gpio_setup (const struct leds_interface_options_gpio *options);
+    void leds_gpio_close (const struct leds_interface_options_gpio *options);
+#endif

--- a/components/leds/include/leds.h
+++ b/components/leds/include/leds.h
@@ -131,14 +131,24 @@ enum leds_interface leds_interface_for_protocol(enum leds_protocol protocol);
 
 #if CONFIG_LEDS_GPIO_ENABLED
   struct leds_interface_options_gpio {
+    enum leds_interface_gpio_mode {
+      LEDS_GPIO_MODE_NONE,
+
+      /* Set pins after interface setup, keep set after TX end */
+      LEDS_GPIO_MODE_SETUP,
+
+      /* Set pins after interface setup, clear at TX end */
+      LEDS_GPIO_MODE_ACTIVE,
+    } mode;
+
     /**
      * GPIO used for output multiplexing.
-     * The `gpio_out_pins` will be set before TX start, and cleared after TX end.
+     * The `pins` will be set.
      * Any other `gpio_options->pins` will be cleared.
      */
     struct gpio_options *gpio_options;
 
-    gpio_pins_t gpio_out_pins;
+    gpio_pins_t pins;
   };
 #endif
 

--- a/components/leds/interfaces/i2s.h
+++ b/components/leds/interfaces/i2s.h
@@ -59,9 +59,8 @@ struct leds_interface_i2s {
 
   struct i2s_out *i2s_out;
   struct i2s_out_options i2s_out_options;
-
-  struct gpio_options *gpio_options;
-  gpio_pins_t gpio_out_pins;
+  
+  struct leds_interface_options_gpio gpio;
 };
 
 size_t leds_interface_i2s_buffer_size(enum leds_interface_i2s_mode mode, unsigned led_count, unsigned pin_count);

--- a/components/leds/interfaces/i2s/tx.c
+++ b/components/leds/interfaces/i2s/tx.c
@@ -1,6 +1,7 @@
 #include "../i2s.h"
 #include "../../leds.h"
 #include "../../stats.h"
+#include "../../gpio.h"
 
 #include <logging.h>
 
@@ -288,8 +289,7 @@ int leds_interface_i2s_init(struct leds_interface_i2s *interface, const struct l
   interface->i2s_out_options.inv_data_gpio = options->inv_data_pin;
 #endif
 
-  interface->gpio_options = options->gpio.gpio_options;
-  interface->gpio_out_pins = options->gpio.gpio_out_pins;
+  interface->gpio = options->gpio;
 
   return 0;
 }
@@ -332,9 +332,7 @@ int leds_interface_i2s_tx(struct leds_interface_i2s *interface, const struct led
   }
 
 #if CONFIG_LEDS_GPIO_ENABLED
-  if (interface->gpio_options) {
-    gpio_out_set(interface->gpio_options, interface->gpio_out_pins);
-  }
+  leds_gpio_setup(&interface->gpio);
 #endif
 
   WITH_STATS_TIMER(&stats->write) {
@@ -352,9 +350,7 @@ int leds_interface_i2s_tx(struct leds_interface_i2s *interface, const struct led
 
 error:
 #if CONFIG_LEDS_GPIO_ENABLED
-  if (interface->gpio_options) {
-    gpio_out_clear(interface->gpio_options);
-  }
+  leds_gpio_close(&interface->gpio);
 #endif
 
   if ((err = i2s_out_close(interface->i2s_out))) {

--- a/components/leds/interfaces/spi.h
+++ b/components/leds/interfaces/spi.h
@@ -65,8 +65,7 @@
     spi_device_handle_t device;
   #endif
 
-    struct gpio_options *gpio_options;
-    gpio_pins_t gpio_out_pins;
+    struct leds_interface_options_gpio gpio;
   };
 
   size_t leds_interface_spi_buffer_size(enum leds_interface_spi_mode mode, unsigned count);

--- a/components/leds/interfaces/spi/interface.c
+++ b/components/leds/interfaces/spi/interface.c
@@ -1,6 +1,7 @@
 #include "../spi.h"
 #include "../../leds.h"
 #include "../../stats.h"
+#include "../../gpio.h"
 
 #include <logging.h>
 
@@ -189,8 +190,7 @@ int leds_interface_spi_init(struct leds_interface_spi *interface, const struct l
     return err;
   }
 
-  interface->gpio_options = options->gpio.gpio_options;
-  interface->gpio_out_pins = options->gpio.gpio_out_pins;
+  interface->gpio = options->gpio;
 
   return 0;
 }
@@ -302,9 +302,7 @@ int leds_interface_spi_tx(struct leds_interface_spi *interface, const struct led
   }
 
 #if CONFIG_LEDS_GPIO_ENABLED
-  if (interface->gpio_options) {
-    gpio_out_set(interface->gpio_options, interface->gpio_out_pins);
-  }
+  leds_gpio_setup(&interface->gpio);
 #endif
 
   WITH_STATS_TIMER(&stats->tx) {
@@ -327,9 +325,7 @@ int leds_interface_spi_tx(struct leds_interface_spi *interface, const struct led
 
 error:
 #if CONFIG_LEDS_GPIO_ENABLED
-  if (interface->gpio_options) {
-    gpio_out_clear(interface->gpio_options);
-  }
+  leds_gpio_close(&interface->gpio);
 #endif
 
   if ((err = leds_interface_spi_master_close(interface))) {

--- a/components/leds/interfaces/uart.h
+++ b/components/leds/interfaces/uart.h
@@ -35,8 +35,7 @@
     struct uart *uart;
     struct uart_options uart_options;
 
-    struct gpio_options *gpio_options;
-    gpio_pins_t gpio_out_pins;
+    struct leds_interface_options_gpio gpio;
   };
 
   int leds_interface_uart_init(struct leds_interface_uart *interface, const struct leds_interface_uart_options *options, enum leds_interface_uart_mode mode, union leds_interface_uart_func func);

--- a/components/leds/interfaces/uart/tx.c
+++ b/components/leds/interfaces/uart/tx.c
@@ -1,6 +1,7 @@
 #include "../uart.h"
 #include "../../leds.h"
 #include "../../stats.h"
+#include "../../gpio.h"
 
 #include <logging.h>
 
@@ -56,8 +57,7 @@ int leds_interface_uart_init(struct leds_interface_uart *interface, const struct
 
   interface->uart_options.pin_mutex = options->pin_mutex;
 
-  interface->gpio_options = options->gpio.gpio_options;
-  interface->gpio_out_pins = options->gpio.gpio_out_pins;
+  interface->gpio = options->gpio;
 
   return 0;
 }
@@ -116,9 +116,7 @@ int leds_interface_uart_tx(struct leds_interface_uart *interface, const struct l
   }
 
 #if CONFIG_LEDS_GPIO_ENABLED
-  if (interface->gpio_options) {
-    gpio_out_set(interface->gpio_options, interface->gpio_out_pins);
-  }
+  leds_gpio_setup(&interface->gpio);
 #endif
 
   WITH_STATS_TIMER(&stats->tx) {
@@ -143,9 +141,7 @@ int leds_interface_uart_tx(struct leds_interface_uart *interface, const struct l
 
 error:
 #if CONFIG_LEDS_GPIO_ENABLED
-  if (interface->gpio_options) {
-    gpio_out_clear(interface->gpio_options);
-  }
+  leds_gpio_close(&interface->gpio);
 #endif
 
   if ((err = uart_close(interface->uart))) {

--- a/main/atx_psu_config.c
+++ b/main/atx_psu_config.c
@@ -10,9 +10,9 @@
 struct atx_psu_config atx_psu_config = {};
 
 const struct config_enum atx_psu_gpio_mode_enum[] = {
-  { "",     ATX_PSU_GPIO_MODE_DISABLED  },
-  { "LOW",  ATX_PSU_GPIO_MODE_LOW       },
-  { "HIGH", ATX_PSU_GPIO_MODE_HIGH      },
+  { "",     .value = ATX_PSU_GPIO_MODE_DISABLED  },
+  { "LOW",  .value = ATX_PSU_GPIO_MODE_LOW       },
+  { "HIGH", .value = ATX_PSU_GPIO_MODE_HIGH      },
   {}
 };
 

--- a/main/dmx_config.c
+++ b/main/dmx_config.c
@@ -11,18 +11,18 @@ struct dmx_input_config dmx_input_config = {};
 struct dmx_output_config dmx_output_configs[DMX_OUTPUT_COUNT] = {};
 
 const struct config_enum dmx_uart_enum[] = {
-  { "",        -1      },
+  { "",           .value = -1      },
 #if defined(UART_0) && CONFIG_ESP_CONSOLE_UART_NUM != 0
-  { "UART0",      UART_0  },
+  { "UART0",      .value = UART_0  },
 #endif
 #if defined(UART_0_SWAP) && CONFIG_ESP_CONSOLE_UART_NUM != 0
-  { "UART0_SWAP", UART_0_SWAP  }, // ESP8266 specialty
+  { "UART0_SWAP", .value = UART_0_SWAP  }, // ESP8266 specialty
 #endif
 #if defined(UART_1) && CONFIG_ESP_CONSOLE_UART_NUM != 1
-  { "UART1",      UART_1  },
+  { "UART1",      .value = UART_1  },
 #endif
 #if defined(UART_2) && CONFIG_ESP_CONSOLE_UART_NUM != 2
-  { "UART2",      UART_2  },
+  { "UART2",      .value = UART_2  },
 #endif
  {}
 };
@@ -40,9 +40,9 @@ const struct config_enum dmx_uart_enum[] = {
 #endif
 
 const struct config_enum dmx_gpio_mode_enum[] = {
-  { "",     DMX_GPIO_MODE_DISABLED  },
-  { "LOW",  DMX_GPIO_MODE_LOW       },
-  { "HIGH", DMX_GPIO_MODE_HIGH      },
+  { "",     .value = DMX_GPIO_MODE_DISABLED  },
+  { "LOW",  .value = DMX_GPIO_MODE_LOW       },
+  { "HIGH", .value = DMX_GPIO_MODE_HIGH      },
   {}
 };
 

--- a/main/esp32/leds_spi.c
+++ b/main/esp32/leds_spi.c
@@ -16,15 +16,15 @@
   };
 
   const struct config_enum leds_spi_host_enum[] = {
-    { "",       -1        },
+    { "",       .value = -1        },
   #if SOC_SPI_PERIPH_NUM >= 1
-    { "SPI1",   SPI1_HOST },
+    { "SPI1",   .value = SPI1_HOST },
   #endif
   #if (SOC_SPI_PERIPH_NUM >= 2) && !CONFIG_SDCARD_SPI_HOST
-    { "SPI2",   SPI2_HOST },
+    { "SPI2",   .value = SPI2_HOST },
   #endif
   #if SOC_SPI_PERIPH_NUM >= 3
-    { "SPI3",   SPI3_HOST },
+    { "SPI3",   .value = SPI3_HOST },
   #endif
     {}
   };

--- a/main/eth_config.c
+++ b/main/eth_config.c
@@ -52,11 +52,11 @@
 #endif
 
   const struct config_enum eth_mode_enum[] = {
-    { "NONE",         ETH_MODE_NONE         },
-    { "STATIC",       ETH_MODE_STATIC       },
-    { "AUTOCONF",     ETH_MODE_AUTOCONF     },
-    { "DHCP_CLIENT",  ETH_MODE_DHCP_CLIENT  },
-    { "DHCP_SERVER",  ETH_MODE_DHCP_SERVER  },
+    { "NONE",         .value = ETH_MODE_NONE         },
+    { "STATIC",       .value = ETH_MODE_STATIC       },
+    { "AUTOCONF",     .value = ETH_MODE_AUTOCONF     },
+    { "DHCP_CLIENT",  .value = ETH_MODE_DHCP_CLIENT  },
+    { "DHCP_SERVER",  .value = ETH_MODE_DHCP_SERVER  },
     {}
   };
 

--- a/main/gpio.c
+++ b/main/gpio.c
@@ -10,13 +10,13 @@
 
 
 const struct config_enum gpio_type_enum[] = {
-  { "HOST",       GPIO_TYPE_HOST              },
+  { "HOST",       .value = GPIO_TYPE_HOST       },
 #if CONFIG_I2C_GPIO_ENABLED
-  { "I2C-GPIO0",  GPIO_TYPE_I2C_DEV(0) },
-  { "I2C-GPIO1",  GPIO_TYPE_I2C_DEV(1) },
-  { "I2C-GPIO2",  GPIO_TYPE_I2C_DEV(2) },
-  { "I2C-GPIO3",  GPIO_TYPE_I2C_DEV(3) },
-  { "I2C-GPIO4",  GPIO_TYPE_I2C_DEV(4) },
+  { "I2C-GPIO0",  .value = GPIO_TYPE_I2C_DEV(0) },
+  { "I2C-GPIO1",  .value = GPIO_TYPE_I2C_DEV(1) },
+  { "I2C-GPIO2",  .value = GPIO_TYPE_I2C_DEV(2) },
+  { "I2C-GPIO3",  .value = GPIO_TYPE_I2C_DEV(3) },
+  { "I2C-GPIO4",  .value = GPIO_TYPE_I2C_DEV(4) },
 #endif
   {},
 };

--- a/main/i2c_gpio.c
+++ b/main/i2c_gpio.c
@@ -6,9 +6,9 @@
 
 #if GPIO_I2C_ENABLED
   const struct config_enum i2c_gpio_type_enum[] = {
-    { "",         GPIO_I2C_TYPE_NONE        },
-    { "PCA9534",  GPIO_I2C_TYPE_PCA9534     },
-    { "PCA9554",  GPIO_I2C_TYPE_PCA9554     },
+    { "",         .value = GPIO_I2C_TYPE_NONE        },
+    { "PCA9534",  .value = GPIO_I2C_TYPE_PCA9534     },
+    { "PCA9554",  .value = GPIO_I2C_TYPE_PCA9554     },
     {},
   };
 #endif

--- a/main/leds_config.c
+++ b/main/leds_config.c
@@ -85,9 +85,11 @@ const struct config_enum leds_i2s_clock_enum[] = {
 
 #if CONFIG_LEDS_GPIO_ENABLED
 const struct config_enum leds_gpio_mode_enum[] = {
-  { "",     LEDS_GPIO_MODE_DISABLED   },
-  { "LOW",  LEDS_GPIO_MODE_LOW        },
-  { "HIGH", LEDS_GPIO_MODE_HIGH       },
+  { "",             LEDS_CONFIG_GPIO_MODE_DISABLED        },
+  { "SETUP_LOW",    LEDS_CONFIG_GPIO_MODE_SETUP_LOW       },
+  { "SETUP_HIGH",   LEDS_CONFIG_GPIO_MODE_SETUP_HIGH      },
+  { "ACTIVE_LOW",   LEDS_CONFIG_GPIO_MODE_ACTIVE_LOW      },
+  { "ACTIVE_HIGH",  LEDS_CONFIG_GPIO_MODE_ACTIVE_HIGH     },
   {}
 };
 #endif

--- a/main/leds_config.c
+++ b/main/leds_config.c
@@ -85,11 +85,11 @@ const struct config_enum leds_i2s_clock_enum[] = {
 
 #if CONFIG_LEDS_GPIO_ENABLED
 const struct config_enum leds_gpio_mode_enum[] = {
-  { "",             .value = LEDS_CONFIG_GPIO_MODE_DISABLED    },
-  { "SETUP_LOW",    .value = LEDS_CONFIG_GPIO_MODE_SETUP_LOW   },
-  { "SETUP_HIGH",   .value = LEDS_CONFIG_GPIO_MODE_SETUP_HIGH  },
-  { "ACTIVE_LOW",   .value = LEDS_CONFIG_GPIO_MODE_ACTIVE_LOW, },
-  { "ACTIVE_HIGH",  .value = LEDS_CONFIG_GPIO_MODE_ACTIVE_HIGH },
+  { "",                               .value = LEDS_CONFIG_GPIO_MODE_DISABLED    },
+  { "SETUP_LOW",                      .value = LEDS_CONFIG_GPIO_MODE_SETUP_LOW   },
+  { "SETUP_HIGH",                     .value = LEDS_CONFIG_GPIO_MODE_SETUP_HIGH  },
+  { "ACTIVE_LOW",   .alias = "LOW",   .value = LEDS_CONFIG_GPIO_MODE_ACTIVE_LOW, },
+  { "ACTIVE_HIGH",  .alias = "HIGH",  .value = LEDS_CONFIG_GPIO_MODE_ACTIVE_HIGH },
   {}
 };
 #endif

--- a/main/leds_config.c
+++ b/main/leds_config.c
@@ -16,119 +16,119 @@
 struct leds_config leds_configs[LEDS_COUNT] = {};
 
 const struct config_enum leds_interface_enum[] = {
-  { "DEFAULT",  LEDS_INTERFACE_NONE   },
+  { "DEFAULT",  .value = LEDS_INTERFACE_NONE   },
 #if CONFIG_LEDS_SPI_ENABLED
-  { "SPI",      LEDS_INTERFACE_SPI    },
+  { "SPI",      .value = LEDS_INTERFACE_SPI    },
 #endif
 #if CONFIG_LEDS_UART_ENABLED
-  { "UART",     LEDS_INTERFACE_UART   },
+  { "UART",     .value = LEDS_INTERFACE_UART   },
 #endif
 #if CONFIG_LEDS_I2S_ENABLED
-  { "I2S",      LEDS_INTERFACE_I2S    },
+  { "I2S",      .value = LEDS_INTERFACE_I2S    },
 #endif
   {}
 };
 
 const struct config_enum leds_protocol_enum[] = {
-  { "NONE",         LEDS_PROTOCOL_NONE        },
-  { "APA102",       LEDS_PROTOCOL_APA102      },
-  { "P9813",        LEDS_PROTOCOL_P9813       },
-  { "WS2812B",      LEDS_PROTOCOL_WS2812B     },
-  { "SK6812_GRBW",  LEDS_PROTOCOL_SK6812_GRBW },
-  { "WS2811",       LEDS_PROTOCOL_WS2811      },
-  { "SK9822",       LEDS_PROTOCOL_SK9822      },
-  { "SM16703",      LEDS_PROTOCOL_SM16703     },
+  { "NONE",         .value = LEDS_PROTOCOL_NONE        },
+  { "APA102",       .value = LEDS_PROTOCOL_APA102      },
+  { "P9813",        .value = LEDS_PROTOCOL_P9813       },
+  { "WS2812B",      .value = LEDS_PROTOCOL_WS2812B     },
+  { "SK6812_GRBW",  .value = LEDS_PROTOCOL_SK6812_GRBW },
+  { "WS2811",       .value = LEDS_PROTOCOL_WS2811      },
+  { "SK9822",       .value = LEDS_PROTOCOL_SK9822      },
+  { "SM16703",      .value = LEDS_PROTOCOL_SM16703     },
   {}
 };
 
 #if CONFIG_LEDS_SPI_ENABLED && !CONFIG_IDF_TARGET_ESP8266
 const struct config_enum leds_spi_cs_mode_enum[] = {
-  { "",     LEDS_SPI_CS_MODE_DISABLED },
-  { "HIGH", LEDS_SPI_CS_MODE_HIGH     },
-  { "LOW",  LEDS_SPI_CS_MODE_LOW      },
+  { "",     .value = LEDS_SPI_CS_MODE_DISABLED },
+  { "HIGH", .value = LEDS_SPI_CS_MODE_HIGH     },
+  { "LOW",  .value = LEDS_SPI_CS_MODE_LOW      },
   {}
 };
 #endif
 
 #if CONFIG_LEDS_SPI_ENABLED
 const struct config_enum leds_spi_clock_enum[] = {
-  { "20M",  SPI_CLOCK_20MHZ   },
-  { "10M",  SPI_CLOCK_10MHZ   },
-  { "5M",   SPI_CLOCK_5MHZ    },
-  { "2M",   SPI_CLOCK_2MHZ    },
-  { "1M",   SPI_CLOCK_1MHZ    },
-  { "500K", SPI_CLOCK_500KHZ  },
-  { "200K", SPI_CLOCK_200KHZ  },
-  { "100K", SPI_CLOCK_100KHZ  },
-  { "50K",  SPI_CLOCK_50KHZ   },
-  { "20K",  SPI_CLOCK_20KHZ   },
-  { "10K",  SPI_CLOCK_10KHZ   },
-  { "1K",   SPI_CLOCK_1KHZ    },
+  { "20M",  .value = SPI_CLOCK_20MHZ   },
+  { "10M",  .value = SPI_CLOCK_10MHZ   },
+  { "5M",   .value = SPI_CLOCK_5MHZ    },
+  { "2M",   .value = SPI_CLOCK_2MHZ    },
+  { "1M",   .value = SPI_CLOCK_1MHZ    },
+  { "500K", .value = SPI_CLOCK_500KHZ  },
+  { "200K", .value = SPI_CLOCK_200KHZ  },
+  { "100K", .value = SPI_CLOCK_100KHZ  },
+  { "50K",  .value = SPI_CLOCK_50KHZ   },
+  { "20K",  .value = SPI_CLOCK_20KHZ   },
+  { "10K",  .value = SPI_CLOCK_10KHZ   },
+  { "1K",   .value = SPI_CLOCK_1KHZ    },
   {}
 };
 #endif
 
 #if CONFIG_LEDS_I2S_ENABLED
 const struct config_enum leds_i2s_clock_enum[] = {
-  { "20M",  I2S_CLOCK_20MHZ   },
-  { "10M",  I2S_CLOCK_10MHZ   },
-  { "5M",   I2S_CLOCK_5MHZ    },
-  { "2M",   I2S_CLOCK_2MHZ    },
-  { "1M",   I2S_CLOCK_1MHZ    },
-  { "500K", I2S_CLOCK_500KHZ  },
-  { "200K", I2S_CLOCK_200KHZ  },
-  { "100K", I2S_CLOCK_100KHZ  },
-  { "50K",  I2S_CLOCK_50KHZ   },
+  { "20M",  .value = I2S_CLOCK_20MHZ   },
+  { "10M",  .value = I2S_CLOCK_10MHZ   },
+  { "5M",   .value = I2S_CLOCK_5MHZ    },
+  { "2M",   .value = I2S_CLOCK_2MHZ    },
+  { "1M",   .value = I2S_CLOCK_1MHZ    },
+  { "500K", .value = I2S_CLOCK_500KHZ  },
+  { "200K", .value = I2S_CLOCK_200KHZ  },
+  { "100K", .value = I2S_CLOCK_100KHZ  },
+  { "50K",  .value = I2S_CLOCK_50KHZ   },
   {}
 };
 #endif
 
 #if CONFIG_LEDS_GPIO_ENABLED
 const struct config_enum leds_gpio_mode_enum[] = {
-  { "",             LEDS_CONFIG_GPIO_MODE_DISABLED        },
-  { "SETUP_LOW",    LEDS_CONFIG_GPIO_MODE_SETUP_LOW       },
-  { "SETUP_HIGH",   LEDS_CONFIG_GPIO_MODE_SETUP_HIGH      },
-  { "ACTIVE_LOW",   LEDS_CONFIG_GPIO_MODE_ACTIVE_LOW      },
-  { "ACTIVE_HIGH",  LEDS_CONFIG_GPIO_MODE_ACTIVE_HIGH     },
+  { "",             .value = LEDS_CONFIG_GPIO_MODE_DISABLED    },
+  { "SETUP_LOW",    .value = LEDS_CONFIG_GPIO_MODE_SETUP_LOW   },
+  { "SETUP_HIGH",   .value = LEDS_CONFIG_GPIO_MODE_SETUP_HIGH  },
+  { "ACTIVE_LOW",   .value = LEDS_CONFIG_GPIO_MODE_ACTIVE_LOW, },
+  { "ACTIVE_HIGH",  .value = LEDS_CONFIG_GPIO_MODE_ACTIVE_HIGH },
   {}
 };
 #endif
 
 const struct config_enum leds_format_enum[] = {
-  { "RGB",    LEDS_FORMAT_RGB     },
-  { "BGR",    LEDS_FORMAT_BGR     },
-  { "GRB",    LEDS_FORMAT_GRB     },
-  { "RGBA",   LEDS_FORMAT_RGBA    },
-  { "RGBW",   LEDS_FORMAT_RGBW    },
-  { "RGBxI",  LEDS_FORMAT_RGBXI   },
-  { "RGBWxI", LEDS_FORMAT_RGBWXI  },
+  { "RGB",    .value = LEDS_FORMAT_RGB     },
+  { "BGR",    .value = LEDS_FORMAT_BGR     },
+  { "GRB",    .value = LEDS_FORMAT_GRB     },
+  { "RGBA",   .value = LEDS_FORMAT_RGBA    },
+  { "RGBW",   .value = LEDS_FORMAT_RGBW    },
+  { "RGBxI",  .value = LEDS_FORMAT_RGBXI   },
+  { "RGBWxI", .value = LEDS_FORMAT_RGBWXI  },
   {}
 };
 
 const struct config_enum leds_test_mode_enum[] = {
-  { "NONE",           TEST_MODE_NONE          },
-  { "CHASE",          TEST_MODE_CHASE         },
-  { "BLACK_RED",      TEST_MODE_BLACK_RED     },
-  { "RED_YELLOW",     TEST_MODE_RED_YELLOW    },
-  { "YELLOW_GREEN",   TEST_MODE_YELLOW_GREEN  },
-  { "GREEN_CYAN",     TEST_MODE_GREEN_CYAN    },
-  { "CYAN_BLUE",      TEST_MODE_CYAN_BLUE     },
-  { "BLUE_MAGENTA",   TEST_MODE_BLUE_MAGENTA  },
-  { "MAGENTA_RED",    TEST_MODE_MAGENTA_RED   },
-  { "RED_BLACK",      TEST_MODE_RED_BLACK     },
-  { "BLACK_WHITE",    TEST_MODE_BLACK_WHITE   },
-  { "WHITE_RGBW",     TEST_MODE_WHITE_RGBW    },
-  { "RGBW_RGB",       TEST_MODE_RGBW_RGB      },
-  { "RGB_BLACK",      TEST_MODE_RGB_BLACK     },
-  { "RAINBOW",        TEST_MODE_RAINBOW       },
-  { "BLACK",          TEST_MODE_BLACK         },
+  { "NONE",           .value = TEST_MODE_NONE          },
+  { "CHASE",          .value = TEST_MODE_CHASE         },
+  { "BLACK_RED",      .value = TEST_MODE_BLACK_RED     },
+  { "RED_YELLOW",     .value = TEST_MODE_RED_YELLOW    },
+  { "YELLOW_GREEN",   .value = TEST_MODE_YELLOW_GREEN  },
+  { "GREEN_CYAN",     .value = TEST_MODE_GREEN_CYAN    },
+  { "CYAN_BLUE",      .value = TEST_MODE_CYAN_BLUE     },
+  { "BLUE_MAGENTA",   .value = TEST_MODE_BLUE_MAGENTA  },
+  { "MAGENTA_RED",    .value = TEST_MODE_MAGENTA_RED   },
+  { "RED_BLACK",      .value = TEST_MODE_RED_BLACK     },
+  { "BLACK_WHITE",    .value = TEST_MODE_BLACK_WHITE   },
+  { "WHITE_RGBW",     .value = TEST_MODE_WHITE_RGBW    },
+  { "RGBW_RGB",       .value = TEST_MODE_RGBW_RGB      },
+  { "RGB_BLACK",      .value = TEST_MODE_RGB_BLACK     },
+  { "RAINBOW",        .value = TEST_MODE_RAINBOW       },
+  { "BLACK",          .value = TEST_MODE_BLACK         },
   {}
 };
 
 const struct config_enum leds_parameter_enum[] = {
-  { "NONE",     LEDS_PARAMETER_NONE   },
-  { "DIMMER",   LEDS_PARAMETER_DIMMER },
-  { "WHITE",    LEDS_PARAMETER_WHITE  },
+  { "NONE",     .value = LEDS_PARAMETER_NONE   },
+  { "DIMMER",   .value = LEDS_PARAMETER_DIMMER },
+  { "WHITE",    .value = LEDS_PARAMETER_WHITE  },
   {}
 };
 

--- a/main/leds_config.h
+++ b/main/leds_config.h
@@ -17,10 +17,12 @@ struct leds_state *state;
 
   #define LEDS_GPIO_SIZE 8
 
-  enum leds_gpio_mode {
-    LEDS_GPIO_MODE_DISABLED = -1,
-    LEDS_GPIO_MODE_LOW      = 0,
-    LEDS_GPIO_MODE_HIGH     = 1,
+  enum leds_config_gpio_mode {
+    LEDS_CONFIG_GPIO_MODE_DISABLED,
+    LEDS_CONFIG_GPIO_MODE_SETUP_LOW,
+    LEDS_CONFIG_GPIO_MODE_SETUP_HIGH,
+    LEDS_CONFIG_GPIO_MODE_ACTIVE_LOW,
+    LEDS_CONFIG_GPIO_MODE_ACTIVE_HIGH,
   };
 
   extern const struct config_enum leds_gpio_mode_enum[];

--- a/main/leds_configtab.i
+++ b/main/leds_configtab.i
@@ -92,11 +92,15 @@ const struct configtab LEDS_CONFIGTAB[] = {
     .enum_type = { .value = &LEDS_CONFIG.gpio_type, .values = gpio_type_enum, .default_value = GPIO_TYPE_HOST },
   },
   { CONFIG_TYPE_ENUM, "gpio_mode",
-    .description = "Multiplex between multiple active-high/low GPIO-controlled outputs",
-    .enum_type = { .value = &LEDS_CONFIG.gpio_mode, .values = leds_gpio_mode_enum, .default_value = LEDS_GPIO_MODE_DISABLED },
+    .description = (
+      "Control multiple active-high/low GPIO-controlled outputs based on LEDS state."
+      " SETUP -> active once interface is first setup, remains active while idle."
+      " ACTIVE -> active when interface is setup and ready to transmit, inactive once idle."
+    ),
+    .enum_type = { .value = &LEDS_CONFIG.gpio_mode, .values = leds_gpio_mode_enum, .default_value = LEDS_CONFIG_GPIO_MODE_DISABLED },
   },
   { CONFIG_TYPE_UINT16, "gpio_pin",
-    .description = "GPIO pin to activate when transmitting on this output",
+    .description = "GPIO pin to activate when output is setup/active",
     .count = &LEDS_CONFIG.gpio_count, .size = LEDS_GPIO_SIZE,
     .uint16_type = { .value = LEDS_CONFIG.gpio_pin, .max = GPIO_PIN_MAX },
   },

--- a/main/leds_i2s.c
+++ b/main/leds_i2s.c
@@ -17,12 +17,12 @@
   };
 
   const struct config_enum leds_i2s_port_enum[] = {
-    { "",              -1           },
+    { "",             .value = -1           },
   #if defined(I2S_PORT_0)
-    { "I2S0",         I2S_PORT_0    },
+    { "I2S0",         .value = I2S_PORT_0    },
   #endif
   #if defined(I2S_PORT_1)
-    { "I2S1",         I2S_PORT_1    },
+    { "I2S1",         .value = I2S_PORT_1    },
   #endif
     {},
   };

--- a/main/leds_uart.c
+++ b/main/leds_uart.c
@@ -11,15 +11,15 @@
   };
 
   const struct config_enum leds_uart_port_enum[] = {
-    { "",              -1       },
+    { "",              .value = -1       },
   #if defined(UART_0) && CONFIG_ESP_CONSOLE_UART_NUM != 0
-    { "UART0",         UART_0   },
+    { "UART0",         .value = UART_0   },
   #endif
   #if defined(UART_1) && CONFIG_ESP_CONSOLE_UART_NUM != 1
-    { "UART1",         UART_1   },
+    { "UART1",         .value = UART_1   },
   #endif
   #if defined(UART_2) && CONFIG_ESP_CONSOLE_UART_NUM != 2
-    { "UART2",         UART_2   },
+    { "UART2",         .value = UART_2   },
   #endif
     {},
   };

--- a/main/wifi_config.c
+++ b/main/wifi_config.c
@@ -25,23 +25,23 @@
 struct wifi_config wifi_config = {};
 
 const struct config_enum wifi_mode_enum[] = {
-  { "OFF",    WIFI_MODE_NULL  },
-  { "STA",    WIFI_MODE_STA   },
-  { "AP",     WIFI_MODE_AP    },
+  { "OFF",    .value = WIFI_MODE_NULL  },
+  { "STA",    .value = WIFI_MODE_STA   },
+  { "AP",     .value = WIFI_MODE_AP    },
   // TODO: AP/STA?
   {}
 };
 
 const struct config_enum wifi_auth_mode_enum[] = {
-  { "OPEN",           WIFI_AUTH_OPEN },
-  { "WEP",            WIFI_AUTH_WEP },
-  { "WPA-PSK",        WIFI_AUTH_WPA_PSK },
-  { "WPA2-PSK",       WIFI_AUTH_WPA2_PSK },
-  { "WPA/2-PSK",      WIFI_AUTH_WPA_WPA2_PSK },
-  { "WPA3-PSK",       WIFI_AUTH_WPA3_PSK },
-  { "WPA2/3-PSK",     WIFI_AUTH_WPA2_WPA3_PSK },
+  { "OPEN",           .value = WIFI_AUTH_OPEN },
+  { "WEP",            .value = WIFI_AUTH_WEP },
+  { "WPA-PSK",        .value = WIFI_AUTH_WPA_PSK },
+  { "WPA2-PSK",       .value = WIFI_AUTH_WPA2_PSK },
+  { "WPA/2-PSK",      .value = WIFI_AUTH_WPA_WPA2_PSK },
+  { "WPA3-PSK",       .value = WIFI_AUTH_WPA3_PSK },
+  { "WPA2/3-PSK",     .value = WIFI_AUTH_WPA2_WPA3_PSK },
 #if !CONFIG_IDF_TARGET_ESP8266
-  { "WPAI-PSK",       WIFI_AUTH_WAPI_PSK },
+  { "WPAI-PSK",       .value = WIFI_AUTH_WAPI_PSK },
 #endif
   {}
 };


### PR DESCRIPTION
If the leds GPIO pins are used to drive output-enable pins that leave the LED interface data line in a high-impedance state, then the data line will be sensitive to electrical interference while the interface is idle, which may lead to spurious glitches on the first few connected LEDs.

Add support for `ACTIVE` vs `SETUP` gpio mode, whereby the `SETUP` mode will leave the GPIO pin active once it has been setup (first leds update after boot), and the `ACTIVE` mode acts as before (de-asserts the GPIO pin when the interface is idle).

Also tweak the `i2s_out` pin setup/teardown to leave the data/clock pin outputs enabled (GPIO low state), rather than relying on the output pull-down. This should reduce any susceptibility to interference on the output driver inputs.

Add support for config enum aliases, used to map the old config `LOW` / `HIGH` values -> `ACTIVE_LOW` / `ACTIVE_HIGH` for backwards-compatibility.

# TODO
- SETUP mode doesn't behave as intended if multiple `leds` share the same output interface - only the gpio pins for the last active output will remain active? Perhaps fix this when refactoring the i2s interface to setup at boot?