### PR TITLE
main leds artnet: fix busyloop on state->artnet->timeout_tick if conf…

### DIFF
--- a/main/leds_artnet.c
+++ b/main/leds_artnet.c
@@ -265,7 +265,6 @@ bool leds_artnet_active(struct leds_state *state, EventBits_t event_bits)
 int leds_artnet_update(struct leds_state *state, EventBits_t event_bits)
 {
   struct leds_stats *stats = &leds_stats[state->index];
-  const struct leds_config *config = state->config;
 
   bool data = event_bits & ARTNET_OUTPUT_EVENT_INDEX_BITS;
   bool sync = event_bits & (1 << ARTNET_OUTPUT_EVENT_SYNC_BIT);
@@ -343,7 +342,7 @@ int leds_artnet_update(struct leds_state *state, EventBits_t event_bits)
   // timeouts
   if (data || sync) {
     leds_artnet_timeout_reset(state);
-  } else if (config->artnet_dmx_timeout) {
+  } else if (state->artnet->timeout_tick) {
     if (xTaskGetTickCount() >= state->artnet->timeout_tick) {
       if (leds_artnet_timeout(state)) {
         LOG_WARN("leds_artnet_timeout");


### PR DESCRIPTION
Fixes leds task busyloop -> `task_wdt` trigger if the `artnet_dmx_timeout` config is changed to 0 at runtime with `artnet->timeout_tick`  set.

```
 E (210435) task_wdt: Task watchdog got triggered. The following tasks did not reset the watchdog in time:
E (210435) task_wdt:  - IDLE (CPU 1)
E (210435) task_wdt: Tasks currently running:
E (210435) task_wdt: CPU 0: IDLE
E (210435) task_wdt: CPU 1: leds1
E (210435) task_wdt: Print CPU 0 (current core) backtrace


Backtrace: 0x4010F046:0x3FFB0B20 0x40083221:0x3FFB0B40 0x4017342F:0x3FFBB8B0 0x400D50EE:0x3FFBB8D0 0x4008CB99:0x3FFBB8F0 0x4008FD3D:0x3FFBB910
0x4010f046: task_wdt_isr at /opt/esp-idf/components/esp_system/task_wdt.c:183 (discriminator 3)

0x40083221: _xt_lowint1 at /opt/esp-idf/components/freertos/port/xtensa/xtensa_vectors.S:1114

0x4017342f: cpu_ll_waiti at /opt/esp-idf/components/hal/esp32/include/hal/cpu_ll.h:183
 (inlined by) esp_pm_impl_waiti at /opt/esp-idf/components/esp_pm/pm_impl.c:847

0x400d50ee: esp_vApplicationIdleHook at /opt/esp-idf/components/esp_system/freertos_hooks.c:63

0x4008cb99: prvIdleTask at /opt/esp-idf/components/freertos/tasks.c:3987 (discriminator 1)

0x4008fd3d: vPortTaskWrapper at /opt/esp-idf/components/freertos/port/xtensa/port.c:142


E (210435) task_wdt: Print CPU 1 backtrace


Backtrace: 0x40086B35:0x3FFB1120 0x40083221:0x3FFB1140 0x4000BFED:0x3FFE2DB0 0x4008FFEE:0x3FFE2DC0 0x4008EEDA:0x3FFE2DE0 0x400E1ADE:0x3FFE2E10 0x400E1AF1:0x3FFE2E30 0x4008FD3D:0x3FFE2F20
0x40086b35: esp_crosscore_isr at /opt/esp-idf/components/esp_system/crosscore_int.c:92

0x40083221: _xt_lowint1 at /opt/esp-idf/components/freertos/port/xtensa/xtensa_vectors.S:1114

0x4008ffee: vPortClearInterruptMaskFromISR at /opt/esp-idf/components/freertos/port/xtensa/include/freertos/portmacro.h:571
 (inlined by) vPortExitCritical at /opt/esp-idf/components/freertos/port/xtensa/port.c:332

0x4008eeda: xEventGroupWaitBits at /opt/esp-idf/components/freertos/event_groups.c:451

0x400e1ade: leds_task_wait at /build/main/leds_task.c:87 (discriminator 3)

0x400e1af1: leds_main at /build/main/leds_task.c:104 (discriminator 1)

0x4008fd3d: vPortTaskWrapper at /opt/esp-idf/components/freertos/port/xtensa/port.c:142
```