### PR TITLE
config: fix config show mod index

### DIFF
--- a/components/config/cmd.c
+++ b/components/config/cmd.c
@@ -236,7 +236,7 @@ static void print_config(const struct config *config)
   for (const struct configmod *mod = config->modules; mod->name; mod++) {
     if (mod->tables_count) {
       for (unsigned i = 0; i < mod->tables_count; i++) {
-        print_configmod(mod, i, mod->tables[i]);
+        print_configmod(mod, i + 1, mod->tables[i]);
       }
     } else {
       print_configmod(mod, 0, mod->table);


### PR DESCRIPTION
fixes https://github.com/qmsk/esp/commit/b28e6a23c04ea45f81c650a0063daf8d1b534d25#diff-5281a339b5ed27133f90b6dc4eb7c9277ac970df5b455bdfb85ee9d583a95663L160-L192

Fix off-by-one error in CLI `config show` module index, e.g. `[dmx-output]` and `[dmx-output1]` instead of `[dmx-output1]` and `[dmx-output2]`.