### PR TITLE
UART fixes

### DIFF
--- a/components/cli/CMakeLists.txt
+++ b/components/cli/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
   SRC_DIRS .
   INCLUDE_DIRS "include"
-  REQUIRES cmd
+  REQUIRES cmd stdio
   PRIV_REQUIRES logging
 )

--- a/components/dmx/dmx_input.c
+++ b/components/dmx/dmx_input.c
@@ -242,7 +242,8 @@ int dmx_input_read (struct dmx_input *in)
   // read until data -> break
   while (!in->state_len || read) {
     WITH_STATS_TIMER(&in->stats.uart_rx) {
-      if ((read = uart_read(in->uart, buf, sizeof(buf))) < 0) {
+      // TODO: 1s timeout for most protocol states?
+      if ((read = uart_read(in->uart, buf, sizeof(buf), portMAX_DELAY)) < 0) {
         dmx_input_process_error(in, -read);
         return read;
       }

--- a/components/dmx/dmx_output.c
+++ b/components/dmx/dmx_output.c
@@ -115,12 +115,12 @@ int dmx_output_write (struct dmx_output *out, enum dmx_cmd cmd, void *data, size
 
   WITH_STATS_TIMER(&out->stats.uart_tx) {
     // send break/mark per spec minimums for transmit; actual timings will vary, these are minimums
-    if ((err = uart_break(out->uart, DMX_BREAK_BITS, DMX_MARK_AFTER_BREAK_BITS))) {
+    if ((err = uart_break(out->uart, DMX_BREAK_BITS, DMX_MARK_AFTER_BREAK_BITS, portMAX_DELAY))) {
       LOG_ERROR("uart1_break");
       goto error;
     }
 
-    if ((err = uart_putc(out->uart, cmd)) < 0) {
+    if ((err = uart_putc(out->uart, cmd, portMAX_DELAY)) < 0) {
       LOG_ERROR("uart_putc");
       goto error;
     }
@@ -128,7 +128,7 @@ int dmx_output_write (struct dmx_output *out, enum dmx_cmd cmd, void *data, size
     for (uint8_t *ptr = data; len > 0; ) {
       ssize_t write;
 
-      if ((write = uart_write(out->uart, ptr, len)) < 0) {
+      if ((write = uart_write(out->uart, ptr, len, portMAX_DELAY)) < 0) {
         LOG_ERROR("uart_write");
         err = write;
         goto error;
@@ -138,7 +138,7 @@ int dmx_output_write (struct dmx_output *out, enum dmx_cmd cmd, void *data, size
       len -= write;
     }
 
-    if ((err = uart_flush_write(out->uart))) {
+    if ((err = uart_flush_write(out->uart, portMAX_DELAY))) {
       LOG_ERROR("uart_flush_write");
       goto error;
     }
@@ -164,7 +164,7 @@ int dmx_output_close (struct dmx_output *out)
     gpio_out_clear(out->options.gpio_options);
   }
 
-  if (uart_close_tx(out->uart)) {
+  if (uart_close_tx(out->uart, portMAX_DELAY)) {
     LOG_WARN("uart_close_tx");
   }
 

--- a/components/dmx/include/dmx_uart.h
+++ b/components/dmx/include/dmx_uart.h
@@ -7,17 +7,17 @@
 #define DMX_UART_RX_BUFFER_SIZE (512 + 1)
 #define DMX_UART_TX_BUFFER_SIZE (512 + 1)
 
-#define DMX_UART_MTBP_UNIT (8 * (1000000 / 250000))
-#define DMX_UART_MTBP_MIN (4 * DMX_UART_MTBP_UNIT)
+#define DMX_UART_MTBP_UNIT (8 * (1000000 / 250000)) // us per frame
+#define DMX_UART_MTBP_MIN (4 * DMX_UART_MTBP_UNIT) // 128us
 #define DMX_UART_MTBP_MAX (UART_RX_TIMEOUT_MAX * DMX_UART_MTBP_UNIT)
 
 // SOC supports mapping IO pins
 #define DMX_UART_IO_PINS_SUPPORTED UART_IO_PINS_SUPPORTED
 
 struct dmx_uart_options {
-  // buffer RX FIFO until line idle for this many ~8-bit periods
+  // buffer RX FIFO until line idle for this many us
   // this must be short enough to trigger in the MTBP, or the final bytes in the packet will be lost...
-  uint16_t mtbp_min; // use DMX_UART_MTBP_MIN
+  uint16_t mtbp_min; // us
 
   // Acquire mutex before setting dev interrupts
   SemaphoreHandle_t dev_mutex;

--- a/components/leds/interfaces/uart/tx.c
+++ b/components/leds/interfaces/uart/tx.c
@@ -68,7 +68,7 @@ static int leds_interface_uart_write(struct leds_interface_uart *interface, void
   int write;
 
   while (len) {
-    if ((write = uart_write(interface->uart, ptr, len)) < 0) {
+    if ((write = uart_write(interface->uart, ptr, len, portMAX_DELAY)) < 0) {
       return write;
     }
 
@@ -106,13 +106,13 @@ int leds_interface_uart_tx_reset(struct leds_interface_uart *interface)
 {
   switch (interface->mode) {
     case LEDS_INTERFACE_UART_MODE_24B3I7_0U4_80U:
-      return uart_mark(interface->uart, 80);
+      return uart_mark(interface->uart, 80, portMAX_DELAY);
 
     case LEDS_INTERFACE_UART_MODE_24B2I8_0U25_50U:
-      return uart_mark(interface->uart, 50);
+      return uart_mark(interface->uart, 50, portMAX_DELAY);
 
     case LEDS_INTERFACE_UART_MODE_32B2I6_0U3_80U:
-      return uart_mark(interface->uart, 80);
+      return uart_mark(interface->uart, 80, portMAX_DELAY);
 
     default:
       LOG_FATAL("invalid mode=%d", interface->mode);
@@ -161,7 +161,7 @@ error:
   leds_gpio_close(&interface->gpio);
 #endif
 
-  if ((err = uart_close(interface->uart))) {
+  if ((err = uart_close(interface->uart, portMAX_DELAY))) {
     LOG_ERROR("uart_close");
     return err;
   }

--- a/components/leds/interfaces/uart/tx.c
+++ b/components/leds/interfaces/uart/tx.c
@@ -62,23 +62,40 @@ int leds_interface_uart_init(struct leds_interface_uart *interface, const struct
   return 0;
 }
 
+static int leds_interface_uart_write(struct leds_interface_uart *interface, void *buf, size_t len)
+{
+  const uint8_t *ptr = buf;
+  int write;
+
+  while (len) {
+    if ((write = uart_write(interface->uart, ptr, len)) < 0) {
+      return write;
+    }
+
+    ptr += write;
+    len -= write;
+  }
+
+  return 0;
+}
+
 int leds_interface_uart_tx_pixel(struct leds_interface_uart *interface, const struct leds_color *pixels, unsigned index, const struct leds_limit *limit)
 {
   switch (interface->mode) {
     case LEDS_INTERFACE_UART_MODE_24B3I7_0U4_80U:
       interface->func.uart_mode_24B3I7(interface->buf.uart_mode_24B3I7, pixels, index, limit);
 
-      return uart_write_all(interface->uart, interface->buf.uart_mode_24B3I7, sizeof(interface->buf.uart_mode_24B3I7));
+      return leds_interface_uart_write(interface, interface->buf.uart_mode_24B3I7, sizeof(interface->buf.uart_mode_24B3I7));
 
     case LEDS_INTERFACE_UART_MODE_24B2I8_0U25_50U:
       interface->func.uart_mode_24B2I8(interface->buf.uart_mode_24B2I8, pixels, index, limit);
 
-      return uart_write_all(interface->uart, interface->buf.uart_mode_24B2I8, sizeof(interface->buf.uart_mode_24B2I8));
+      return leds_interface_uart_write(interface, interface->buf.uart_mode_24B2I8, sizeof(interface->buf.uart_mode_24B2I8));
 
     case LEDS_INTERFACE_UART_MODE_32B2I6_0U3_80U:
       interface->func.uart_mode_32B2I6(interface->buf.uart_mode_32B2I6, pixels, index, limit);
 
-      return uart_write_all(interface->uart, interface->buf.uart_mode_32B2I6, sizeof(interface->buf.uart_mode_32B2I6));
+      return leds_interface_uart_write(interface, interface->buf.uart_mode_32B2I6, sizeof(interface->buf.uart_mode_32B2I6));
 
     default:
       LOG_FATAL("invalid mode=%d", interface->mode);

--- a/components/stdio/log.h
+++ b/components/stdio/log.h
@@ -20,9 +20,9 @@ struct stdio_log {
 extern struct stdio_log *stderr_log;
 
 /*
- * Return number of bytes copied.
+ * Guaranteed to succeeed and write all data.
  */
-size_t stdio_log_write(struct stdio_log *log, const void *data, size_t len);
+void stdio_log_write(struct stdio_log *log, const uint8_t *data, size_t len);
 
 /*
  * Return number of bytes copied.

--- a/components/stdio/vfs.c
+++ b/components/stdio/vfs.c
@@ -25,7 +25,7 @@ ssize_t stdio_vfs_write(int fd, const void *data, size_t size)
   switch(fd) {
     case STDOUT_FILENO:
       if (stdio_uart) {
-        return uart_write(stdio_uart, data, size);
+        return uart_write(stdio_uart, data, size, portMAX_DELAY);
       } else {
         os_write(data, size);
         return size;
@@ -35,7 +35,7 @@ ssize_t stdio_vfs_write(int fd, const void *data, size_t size)
       if (!stdio_uart) {
         os_write(data, size);
       } else {
-        if ((ret = uart_write(stdio_uart, data, size)) < 0) {
+        if ((ret = uart_write(stdio_uart, data, size, portMAX_DELAY)) < 0) {
           errno = EIO;
           return -1;
         } else {
@@ -193,7 +193,7 @@ int stdio_vfs_fsync(int fd)
     case STDOUT_FILENO:
     case STDERR_FILENO:
       if (stdio_uart) {
-        return uart_flush_write(stdio_uart);
+        return uart_flush_write(stdio_uart, portMAX_DELAY);
       } else {
         errno = ENODEV;
         return -1;

--- a/components/stdio/vfs.c
+++ b/components/stdio/vfs.c
@@ -134,7 +134,9 @@ int stdio_vfs_fcntl_stdin(int cmd, int arg)
 
     case F_SET_READ_TIMEOUT:
       stdin_read_timeout = arg ? arg : portMAX_DELAY;
-      
+
+      LOG_DEBUG("stdin_read_timeout = %d", stdin_read_timeout);
+
       return 0;
 
     default:

--- a/components/uart/esp32/intr.c
+++ b/components/uart/esp32/intr.c
@@ -162,7 +162,7 @@ void IRAM_ATTR uart_intr_tx_done_handler(struct uart *uart, BaseType_t *task_wok
     LOG_ISR_DEBUG("notify tx_done_notify_task=%p", uart->tx_done_notify_task);
 
     // FIFO is empty, notify task
-    vTaskNotifyGiveFromISR(uart->tx_done_notify_task, task_woken);
+    xTaskNotifyFromISR(uart->tx_done_notify_task, 0, eNoAction, task_woken);
 
     // only once
     uart->tx_done_notify_task = NULL;

--- a/components/uart/esp32/rx.c
+++ b/components/uart/esp32/rx.c
@@ -15,7 +15,7 @@ int uart_rx_init(struct uart *uart, size_t rx_buffer_size)
   if (rx_buffer_size == 0) {
     uart->rx_buffer = NULL;
 
-  } else if (!(uart->rx_buffer = xStreamBufferCreate(rx_buffer_size, 1))) {
+  } else if (!(uart->rx_buffer = xStreamBufferCreate(rx_buffer_size, 0))) {
     LOG_ERROR("xStreamBufferCreate");
     return -1;
   }

--- a/components/uart/esp32/tx.c
+++ b/components/uart/esp32/tx.c
@@ -151,7 +151,7 @@ size_t uart_tx_slow(struct uart *uart, const uint8_t *buf, size_t len, TickType_
   return write;
 }
 
-int uart_tx_flush(struct uart *uart)
+int uart_tx_flush(struct uart *uart, TickType_t timeout)
 {
   TaskHandle_t task = xTaskGetCurrentTaskHandle();
   bool idle = false, done = false;
@@ -191,8 +191,11 @@ int uart_tx_flush(struct uart *uart)
     LOG_DEBUG("wait done=%d...", done);
 
     // wait for tx to complete and break to start
-    if (!xTaskNotifyWait(0, 0, NULL, portMAX_DELAY)) {
+    if (!xTaskNotifyWait(0, 0, NULL, timeout)) {
+      uart->tx_done_notify_task = NULL;
+
       LOG_WARN("timeout");
+      
       return -1;
     }
 

--- a/components/uart/esp32/tx.c
+++ b/components/uart/esp32/tx.c
@@ -195,7 +195,7 @@ int uart_tx_flush(struct uart *uart, TickType_t timeout)
       uart->tx_done_notify_task = NULL;
 
       LOG_WARN("timeout");
-      
+
       return -1;
     }
 
@@ -222,17 +222,17 @@ static void uart_tx_wait(struct uart *uart, unsigned bits)
   ets_delay_us(us);
 }
 
-// ESP-32 txd_brk is tied to TX_DONE, and does nothing if TX idle
+// ESP-32 txd_brk is tied to TX_DONE, and does nothing if TX idle?
 // called after uart_tx_flush() with tx mutex held
 int uart_tx_break(struct uart *uart, unsigned bits)
 {
   LOG_DEBUG("bits=%u", bits);
-
-  uart->dev->conf0.txd_inv = 1;
+  
+  uart_tx_inv(uart, 1);
 
   uart_tx_wait(uart, bits);
 
-  uart->dev->conf0.txd_inv = 0;
+  uart_tx_inv(uart, 0);
 
   LOG_DEBUG("done");
 

--- a/components/uart/esp32/tx.c
+++ b/components/uart/esp32/tx.c
@@ -143,6 +143,8 @@ int uart_tx_flush(struct uart *uart)
 
   LOG_DEBUG("");
 
+  xTaskNotifyStateClear(task);
+
   taskENTER_CRITICAL(&uart->mux);
 
   if (uart->tx_buffer && !xStreamBufferIsEmpty(uart->tx_buffer)) {
@@ -174,7 +176,7 @@ int uart_tx_flush(struct uart *uart)
     LOG_DEBUG("wait done=%d...", done);
 
     // wait for tx to complete and break to start
-    if (!ulTaskNotifyTake(true, portMAX_DELAY)) {
+    if (!xTaskNotifyWait(0, 0, NULL, portMAX_DELAY)) {
       LOG_WARN("timeout");
       return -1;
     }

--- a/components/uart/esp32/tx.c
+++ b/components/uart/esp32/tx.c
@@ -115,29 +115,6 @@ size_t uart_tx_fast(struct uart *uart, const uint8_t *buf, size_t len)
   return write;
 }
 
-size_t uart_tx_buffered(struct uart *uart, const uint8_t *buf, size_t len)
-{
-  size_t write;
-
-  if (!uart->tx_buffer) {
-    LOG_DEBUG("TX buffer disabled");
-    return 0;
-  }
-
-  // write as many bytes as possible, ensure tx buffer is not empty
-  write = xStreamBufferSend(uart->tx_buffer, buf, len, 0);
-
-  LOG_ISR_DEBUG("buf len=%u: write=%u", len, write);
-
-  if (write == 0) {
-    // TX buffer full, enable ISR
-    uart_ll_set_txfifo_empty_thr(uart->dev, UART_TX_EMPTY_THRD_DEFAULT);
-    uart_ll_ena_intr_mask(uart->dev, UART_TX_WRITE_INTR_MASK);
-  }
-
-  return write;
-}
-
 size_t uart_tx_slow(struct uart *uart, const uint8_t *buf, size_t len)
 {
   size_t write;

--- a/components/uart/esp32/tx.c
+++ b/components/uart/esp32/tx.c
@@ -11,7 +11,8 @@ int uart_tx_init(struct uart *uart, size_t tx_buffer_size)
   if (!tx_buffer_size) {
     uart->tx_buffer = NULL;
 
-  } else if (!(uart->tx_buffer = xStreamBufferCreate(tx_buffer_size, 1))) {
+    // TODO: use xTriggerLevelBytes=0
+  } else if (!(uart->tx_buffer = xStreamBufferCreate(tx_buffer_size, 0))) {
     LOG_ERROR("xStreamBufferCreate");
     return -1;
   }

--- a/components/uart/esp32/tx.h
+++ b/components/uart/esp32/tx.h
@@ -10,8 +10,8 @@
 
 #define UART_TX_WRITE_INTR_MASK (UART_INTR_TXFIFO_EMPTY)
 
-/* Custom, HAL does not provide any method to read a single byte */
-static inline void uart_tx_write_txfifo_byte(struct uart *uart, uint8_t byte)
+/* Custom, HAL does not provide any method to write a single byte */
+static inline void uart_tx_fifo_putc(struct uart *uart, uint8_t byte)
 {
   WRITE_PERI_REG(UART_FIFO_AHB_REG(uart->port & UART_PORT_MASK), byte);
 }

--- a/components/uart/esp32/tx.h
+++ b/components/uart/esp32/tx.h
@@ -15,3 +15,8 @@ static inline void uart_tx_fifo_putc(struct uart *uart, uint8_t byte)
 {
   WRITE_PERI_REG(UART_FIFO_AHB_REG(uart->port & UART_PORT_MASK), byte);
 }
+
+static inline void uart_tx_inv(struct uart *uart, bool inv)
+{
+  uart->dev->conf0.txd_inv = inv;
+}

--- a/components/uart/esp8266/tx.c
+++ b/components/uart/esp8266/tx.c
@@ -34,7 +34,7 @@ int uart_tx_setup(struct uart *uart, struct uart_options options)
   return 0;
 }
 
-int uart_tx_one(struct uart *uart, uint8_t byte)
+int uart_tx_one(struct uart *uart, uint8_t byte, TickType_t timeout)
 {
   int ret;
 
@@ -47,7 +47,7 @@ int uart_tx_one(struct uart *uart, uint8_t byte)
 
     ret = 0;
 
-  } else if (xStreamBufferSend(uart->tx_buffer, &byte, 1, portMAX_DELAY) > 0) {
+  } else if (xStreamBufferSend(uart->tx_buffer, &byte, 1, timeout) > 0) {
     LOG_ISR_DEBUG("tx buffer");
 
     // byte was written

--- a/components/uart/esp8266/tx.c
+++ b/components/uart/esp8266/tx.c
@@ -122,12 +122,12 @@ size_t uart_tx_buffered(struct uart *uart, const uint8_t *buf, size_t len)
   return write;
 }
 
-size_t uart_tx_slow(struct uart *uart, const uint8_t *buf, size_t len)
+size_t uart_tx_slow(struct uart *uart, const uint8_t *buf, size_t len, TickType_t timeout)
 {
   size_t write;
 
   // does not use a critical section, inter enable racing with stream send / ISR is harmless
-  write = xStreamBufferSend(uart->tx_buffer, buf, len, portMAX_DELAY);
+  write = xStreamBufferSend(uart->tx_buffer, buf, len, timeout);
 
   LOG_ISR_DEBUG("xStreamBufferSend len=%u: write=%u", len, write);
 

--- a/components/uart/include/uart.h
+++ b/components/uart/include/uart.h
@@ -207,15 +207,6 @@ ssize_t uart_write(struct uart *uart, const void *buf, size_t len);
 int uart_write_all(struct uart *uart, const void *buf, size_t len);
 
 /**
- * Write len bytes from buf into the TX buffer.
- *
- * TX is only started once the TX buffer is full, or uart_flush() is called.
- *
- * Returns 0, or <0 on error.
- */
-ssize_t uart_write_buffered(struct uart *uart, const void *buf, size_t len);
-
-/**
  * Wait for TX buffer + FIFO to empty.
  */
 int uart_flush_write(struct uart *uart);

--- a/components/uart/include/uart.h
+++ b/components/uart/include/uart.h
@@ -202,7 +202,7 @@ int uart_flush_write(struct uart *uart, TickType_t timeout);
  *
  * Return <0 on error.
  */
-int uart_break(struct uart *uart, unsigned break_bits, unsigned mark_bits);
+int uart_break(struct uart *uart, unsigned break_bits, unsigned mark_bits, TickType_t timeout);
 
 /**
  * Flush, and hold mark for >= `mark_bits` bauds once TX is complete.
@@ -211,19 +211,19 @@ int uart_break(struct uart *uart, unsigned break_bits, unsigned mark_bits);
  *
  * Return <0 on error.
  */
-int uart_mark(struct uart *uart, unsigned mark_bits);
+int uart_mark(struct uart *uart, unsigned mark_bits, TickType_t timeout);
 
 /**
  * Flush TX and release TX mutex acquire dusing `uart_open_tx()`.
  */
-int uart_close_tx(struct uart *uart);
+int uart_close_tx(struct uart *uart, TickType_t timeout);
 
 /**
  * Flush TX/RX and release rx/tx mutex acquired using `uart_open()`.
  *
  * WARNING: This does not release any intr, dev or pin state acquired by `uart_open()` -> `uart_setup()`! Use `uart_teardown()`!
  */
-int uart_close(struct uart *uart);
+int uart_close(struct uart *uart, TickType_t timeout);
 
 /*
  * Stop UART interrupts and disassocate from UART device.

--- a/components/uart/include/uart.h
+++ b/components/uart/include/uart.h
@@ -200,13 +200,6 @@ int uart_putc(struct uart *uart, int ch);
 ssize_t uart_write(struct uart *uart, const void *buf, size_t len);
 
 /**
- * Write len bytes from buf. Blocks if TX buffer is full.
- *
- * Returns 0, or <0 on error.
- */
-int uart_write_all(struct uart *uart, const void *buf, size_t len);
-
-/**
  * Wait for TX buffer + FIFO to empty.
  */
 int uart_flush_write(struct uart *uart);

--- a/components/uart/include/uart.h
+++ b/components/uart/include/uart.h
@@ -99,9 +99,6 @@ struct uart_options {
   // invert TX signals
   uint32_t tx_inverted : 1;
 
-  // optional read() timeout, 0 -> portMAX_DELAY
-  TickType_t read_timeout;
-
   // Acquire mutex before setting dev interrupts
   SemaphoreHandle_t dev_mutex;
 
@@ -145,13 +142,6 @@ int uart_open(struct uart *uart, struct uart_options options);
 int uart_open_rx(struct uart *uart);
 
 /**
- * Set timeout for read().
- *
- * @param timeout or portMAX_DELAY to disable
- */
-int uart_set_read_timeout(struct uart *uart, TickType_t timeout);
-
-/**
  * Read data from UART, copying up to size bytes into buf.
  *
  * @return <0 on error, 0 on timeout or break, otherwise number of bytes copied into buf.
@@ -161,7 +151,7 @@ int uart_set_read_timeout(struct uart *uart, TickType_t timeout);
  * @return -EINTR interrupted using uart_abort_read()
  * @return -EINVAL RX disabled (rx_buffer_size=0)
  */
-int uart_read(struct uart *uart, void *buf, size_t size);
+int uart_read(struct uart *uart, void *buf, size_t size, TickType_t timeout);
 
 /**
  * Cause the following uart_read() call, or any currently pending call, to return an error.

--- a/components/uart/include/uart.h
+++ b/components/uart/include/uart.h
@@ -180,19 +180,19 @@ int uart_open_tx(struct uart *uart);
  *
  * Returns ch on success, <0 on error.
  */
-int uart_putc(struct uart *uart, int ch);
+int uart_putc(struct uart *uart, int ch, TickType_t timeout);
 
 /**
  * Write up to len bytes from buf. Blocks if TX buffer is full.
  *
  * Returns number of bytes written, or <0 on error.
  */
-ssize_t uart_write(struct uart *uart, const void *buf, size_t len);
+ssize_t uart_write(struct uart *uart, const void *buf, size_t len, TickType_t timeout);
 
 /**
  * Wait for TX buffer + FIFO to empty.
  */
-int uart_flush_write(struct uart *uart);
+int uart_flush_write(struct uart *uart, TickType_t timeout);
 
 /**
  * Flush -> idle, hold line low for >= `break_bits` bauds to signal break, and return line high (idle) for >= `mark_bits`.

--- a/components/uart/uart.c
+++ b/components/uart/uart.c
@@ -100,7 +100,7 @@ int uart_setup(struct uart *uart, struct uart_options options)
   }
 
   // wait TX idle
-  if ((err = uart_tx_flush(uart))) {
+  if ((err = uart_tx_flush(uart, portMAX_DELAY))) {
     LOG_ERROR("uart_tx_flush");
     goto error;
   }
@@ -423,7 +423,7 @@ int uart_flush_write(struct uart *uart, TickType_t timeout)
   return err;
 }
 
-int uart_break(struct uart *uart, unsigned break_bits, unsigned mark_bits)
+int uart_break(struct uart *uart, unsigned break_bits, unsigned mark_bits, TickType_t timeout)
 {
   int err;
 
@@ -433,7 +433,7 @@ int uart_break(struct uart *uart, unsigned break_bits, unsigned mark_bits)
 
   LOG_DEBUG("break_bits=%u mark_bits=%u", break_bits, mark_bits);
 
-  if ((err = uart_tx_flush(uart))) {
+  if ((err = uart_tx_flush(uart, timeout))) {
     LOG_ERROR("uart_tx_flush");
     goto error;
   }
@@ -464,7 +464,7 @@ error:
   return err;
 }
 
-int uart_mark(struct uart *uart, unsigned mark_bits)
+int uart_mark(struct uart *uart, unsigned mark_bits, TickType_t timeout)
 {
   int err;
 
@@ -474,7 +474,7 @@ int uart_mark(struct uart *uart, unsigned mark_bits)
 
   LOG_DEBUG("mark_bits=%u", mark_bits);
 
-  if ((err = uart_tx_flush(uart))) {
+  if ((err = uart_tx_flush(uart, timeout))) {
     LOG_ERROR("uart_tx_flush");
     goto error;
   }
@@ -492,7 +492,7 @@ error:
   return err;
 }
 
-int uart_close_tx(struct uart *uart)
+int uart_close_tx(struct uart *uart, TickType_t timeout)
 {
   int err;
 
@@ -500,7 +500,7 @@ int uart_close_tx(struct uart *uart)
     return err;
   }
 
-  if ((err = uart_tx_flush(uart))) {
+  if ((err = uart_tx_flush(uart, timeout))) {
     LOG_ERROR("uart_tx_flush");
     goto error;
   }
@@ -516,7 +516,7 @@ error:
 }
 
 /* setup/open */
-int uart_close(struct uart *uart)
+int uart_close(struct uart *uart, TickType_t timeout)
 {
   int err;
 
@@ -524,7 +524,7 @@ int uart_close(struct uart *uart)
     return err;
   }
 
-  if ((err = uart_tx_flush(uart))) {
+  if ((err = uart_tx_flush(uart, timeout))) {
     LOG_ERROR("uart_tx_flush");
     goto error;
   }

--- a/components/uart/uart.c
+++ b/components/uart/uart.c
@@ -426,40 +426,6 @@ ssize_t uart_write(struct uart *uart, const void *buf, size_t len)
   return write;
 }
 
-ssize_t uart_write_all(struct uart *uart, const void *buf, size_t len)
-{
-  size_t write;
-  int err;
-
-  if ((err = uart_acquire_tx(uart))) {
-    return err;
-  }
-
-  while (len > 0) {
-    // fastpath via FIFO queue or TX buffer
-    write = uart_tx_fast(uart, buf, len);
-
-    LOG_DEBUG("tx fast len=%u: write=%u", len, write);
-
-    buf += write;
-    len -= write;
-
-    if (len > 0) {
-      // blocking slowpath via buffer + ISR
-      write = uart_tx_slow(uart, buf, len);
-
-      LOG_DEBUG("tx slow len=%u: write=%u", len, write);
-
-      buf += write;
-      len -= write;
-    }
-  }
-
-  uart_release_tx(uart);
-
-  return 0;
-}
-
 int uart_flush_write(struct uart *uart)
 {
   int err;

--- a/components/uart/uart.c
+++ b/components/uart/uart.c
@@ -460,45 +460,6 @@ ssize_t uart_write_all(struct uart *uart, const void *buf, size_t len)
   return 0;
 }
 
-ssize_t uart_write_buffered(struct uart *uart, const void *buf, size_t len)
-{
-  size_t write;
-  int err;
-
-  if ((err = uart_acquire_tx(uart))) {
-    return err;
-  }
-
-  while (len > 0) {
-    // fastpath via TX buffer, without interrupts
-    write = uart_tx_buffered(uart, buf, len);
-
-    LOG_DEBUG("tx buf len=%u: write=%u", len, write);
-
-    buf += write;
-    len -= write;
-
-    if (len > 0) {
-      // blocking slowpath via buffer + ISR
-      write = uart_tx_slow(uart, buf, len);
-
-      LOG_DEBUG("tx slow len=%u: write=%u", len, write);
-
-      buf += write;
-      len -= write;
-    }
-
-    if (!len) {
-      LOG_WARN("tx stuck, tx_buffer=%p", uart->tx_buffer);
-      return -1;
-    }
-  }
-
-  uart_release_tx(uart);
-
-  return 0;
-}
-
 int uart_flush_write(struct uart *uart)
 {
   int err;

--- a/components/uart/uart.c
+++ b/components/uart/uart.c
@@ -413,7 +413,7 @@ ssize_t uart_write(struct uart *uart, const void *buf, size_t len)
 
   if (!write) {
     // blocking slowpath via buffer + ISR
-    write = uart_tx_slow(uart, buf, len);
+    write = uart_tx_slow(uart, buf, len, portMAX_DELAY);
 
     LOG_DEBUG("tx slow len=%u: write=%u", len, write);
 

--- a/components/uart/uart.c
+++ b/components/uart/uart.c
@@ -382,7 +382,7 @@ int uart_putc(struct uart *uart, int ch)
 
   LOG_DEBUG("ch=%#02x", ch);
 
-  if ((ret = uart_tx_one(uart, ch))) {
+  if ((ret = uart_tx_one(uart, ch, portMAX_DELAY))) {
     goto error;
   } else {
     ret = ch;

--- a/components/uart/uart.c
+++ b/components/uart/uart.c
@@ -416,7 +416,7 @@ int uart_flush_write(struct uart *uart)
     return err;
   }
 
-  err = uart_tx_flush(uart);
+  err = uart_tx_flush(uart, portMAX_DELAY);
 
   uart_release_tx(uart);
 

--- a/components/uart/uart.h
+++ b/components/uart/uart.h
@@ -83,7 +83,7 @@ int uart_tx_one(struct uart *uart, uint8_t byte, TickType_t timeout);
 size_t uart_tx_fast(struct uart *uart, const uint8_t *buf, size_t len);
 size_t uart_tx_slow(struct uart *uart, const uint8_t *buf, size_t len, TickType_t timeout);
 
-int uart_tx_flush(struct uart *uart);
+int uart_tx_flush(struct uart *uart, TickType_t timeout);
 
 int uart_tx_break(struct uart *uart, unsigned bits);
 int uart_tx_mark(struct uart *uart, unsigned bits);

--- a/components/uart/uart.h
+++ b/components/uart/uart.h
@@ -32,8 +32,6 @@ struct uart {
   StreamBufferHandle_t rx_buffer;
   bool rx_overflow, rx_break, rx_error, rx_abort;
 
-  TickType_t read_timeout;
-
   /* TX */
   SemaphoreHandle_t tx_mutex;
   StreamBufferHandle_t tx_buffer;

--- a/components/uart/uart.h
+++ b/components/uart/uart.h
@@ -83,7 +83,7 @@ int uart_tx_setup(struct uart *uart, struct uart_options options);
 int uart_tx_one(struct uart *uart, uint8_t byte);
 
 size_t uart_tx_fast(struct uart *uart, const uint8_t *buf, size_t len);
-size_t uart_tx_slow(struct uart *uart, const uint8_t *buf, size_t len);
+size_t uart_tx_slow(struct uart *uart, const uint8_t *buf, size_t len, TickType_t timeout);
 
 int uart_tx_flush(struct uart *uart);
 

--- a/components/uart/uart.h
+++ b/components/uart/uart.h
@@ -83,7 +83,6 @@ int uart_tx_setup(struct uart *uart, struct uart_options options);
 int uart_tx_one(struct uart *uart, uint8_t byte);
 
 size_t uart_tx_fast(struct uart *uart, const uint8_t *buf, size_t len);
-size_t uart_tx_buffered(struct uart *uart, const uint8_t *buf, size_t len);
 size_t uart_tx_slow(struct uart *uart, const uint8_t *buf, size_t len);
 
 int uart_tx_flush(struct uart *uart);

--- a/components/uart/uart.h
+++ b/components/uart/uart.h
@@ -80,7 +80,7 @@ void uart_rx_abort(struct uart *uart);
 int uart_tx_init(struct uart *uart, size_t tx_buffer_size);
 int uart_tx_setup(struct uart *uart, struct uart_options options);
 
-int uart_tx_one(struct uart *uart, uint8_t byte);
+int uart_tx_one(struct uart *uart, uint8_t byte, TickType_t timeout);
 
 size_t uart_tx_fast(struct uart *uart, const uint8_t *buf, size_t len);
 size_t uart_tx_slow(struct uart *uart, const uint8_t *buf, size_t len, TickType_t timeout);

--- a/main/console.c
+++ b/main/console.c
@@ -10,6 +10,7 @@
 #include <cli.h>
 #include <stdio_uart.h>
 #include <uart.h>
+#include <sys/unistd.h>
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -147,6 +148,12 @@ int start_console_stdio()
 void stop_console_uart()
 {
   LOG_INFO("closing console, use short CONFIG button press to re-start");
+
+  fflush(stdout);
+  fflush(stderr);
+
+  fsync(fileno(stdout));
+  fsync(fileno(stderr));
 
   stdio_detach_uart();
 

--- a/main/dmx_uart.c
+++ b/main/dmx_uart.c
@@ -82,10 +82,10 @@ int start_dmx_uart()
   }
 
   if (input_enabled && dmx_input_config.mtbp_min) {
-    LOG_INFO("use uart mtbp_min=%u for dmx-input", dmx_input_config.mtbp_min);
-
     options.mtbp_min = dmx_input_config.mtbp_min;
   }
+
+  LOG_INFO("uart mtbp_min=%uus for dmx-input", options.mtbp_min);
 
 #if DMX_UART_IO_PINS_SUPPORTED
   if (input_enabled) {


### PR DESCRIPTION
Various small fixes for uart tx:
* Fix stdio to use `uart_write()` and not block unnecessarily on `uart_write_all()`
* Remove `uart_write_all()` and `uart_write_buffered()`
* Avoid potential issues with pre-existing task notify state on `uart_tx_flush()`
* Fix use of critical section for TX buffer vs FIFO checks in `uart_tx_fast()`
* Fix use of critical section in `uart_tx_one()`
  * This was bypassing the TX buffer, which could have lead to corrupted output
  * This was using a potentially blocking `xStreamBufferSend()` call inside a critical section
* Pass explicit timeout parameter to all uart read/write/flush/close calls
* Fix console timeout on esp32
* Fix console stop -> stdout/stderr flush/sync