### PR TITLE
Upgrade esp-idf 4.4.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   NODE_VERSION: 15.x
-  ESP_IDF_VERSION: v4.4.6
+  ESP_IDF_VERSION: v4.4.8
   ESP8266_RTOS_SDK_VERSION: v3.4
 
 jobs:
@@ -79,7 +79,7 @@ jobs:
           context: sdk/esp-idf
           load: true
           push: false
-          tags: qmsk/esp-idf:dev
+          tags: qmsk/esp-idf:${{ env.ESP_IDF_VERSION }}
 
       - name: Build
         run: docker compose -f projects/esp32/docker-compose.yml run --rm build

--- a/projects/esp32/docker-compose.devices.yml
+++ b/projects/esp32/docker-compose.devices.yml
@@ -3,7 +3,7 @@
 services:
 
   flash:
-    image: qmsk/esp-idf:dev
+    image: qmsk/esp-idf:v4.4.8
     volumes:
       - ../..:/build
     working_dir: /build/projects/esp32
@@ -16,7 +16,7 @@ services:
       ESPPORT: "${ESPPORT}"
 
   monitor:
-    image: qmsk/esp-idf:dev
+    image: qmsk/esp-idf:v4.4.8
     volumes:
       - ../..:/build
     working_dir: /build/projects/esp32

--- a/projects/esp32/docker-compose.yml
+++ b/projects/esp32/docker-compose.yml
@@ -3,18 +3,18 @@
 #   $ docker compose run --rm build
 services:
   sdk:
-    image: qmsk/esp-idf:dev
+    image: qmsk/esp-idf:v4.4.8
     build:
       context: ../../sdk/esp-idf
       args:
         # also update .github/workflows/build.yml `ESP_IDF_VERSION`
-        ESP_IDF_VERSION: v4.4.6
+        ESP_IDF_VERSION: v4.4.8
         BUILD_UID: ${BUILD_UID}
         BUILD_GID: ${BUILD_GID}
     command: idf.py --version
 
   build:
-    image: qmsk/esp-idf:dev
+    image: qmsk/esp-idf:v4.4.8
     volumes:
       - ../..:/build
     working_dir: /build/projects/esp32

--- a/sdk/esp-idf/Dockerfile
+++ b/sdk/esp-idf/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:trixie
 
 # dependencies
 #   https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-setup.html


### PR DESCRIPTION
Fixes https://github.com/espressif/esp-idf/commit/9374a2d9ac61ba9f071c700980bee4d15cb930a4 -> ETH hang with `esp.emac: no mem for receive buffer` error